### PR TITLE
[WIP] Allow multiple `should_capture` filters for Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ GovukError.notify(
 )
 ```
 
+### Capture filtering
+
+If you need to have fine-grained control over which exceptions are reported to Sentry,
+and cannot make use of [`excluded_exceptions`][sentry_docs], then this gem exposes
+configuration for determining what should and should not be reported.
+
+This takes the form of a chain of "capture filters". A capture filter is a `Proc`
+that accepts the Sentry error, and returns `true` if the error **should** be reported:
+
+```rb
+GovukError.configure do |config|
+  config.add_capture_filter do |error|
+    return true unless ExampleErrorHandler.should_ignore?(error)
+  end
+end
+```
+
+Note that all capture filters will be run against all raised errors, and if **any** of
+them return something falsy, then the error will **not** be reported.
+
+[sentry_docs]: https://docs.sentry.io/clients/ruby/config/
+
 ## License
 
 [MIT License](LICENSE.md)

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,4 +1,5 @@
 require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
+require "govuk_app_config/govuk_error/configuration"
 require "govuk_app_config/configure"

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -10,4 +10,12 @@ module GovukError
 
     Raven.capture_exception(exception_or_message, args)
   end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
 end

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -1,0 +1,13 @@
+module GovukError
+  class Configuration
+    attr_reader :capture_filters
+
+    def initialize
+      @capture_filters = []
+    end
+
+    def add_capture_filter(&block)
+      @capture_filters << block
+    end
+  end
+end

--- a/spec/integration/configuring_spec.rb
+++ b/spec/integration/configuring_spec.rb
@@ -10,4 +10,86 @@ RSpec.describe 'Requiring govuk_app_config' do
       expect { Raven.configuration.transport_failure_callback.call('foo') }.not_to raise_error
     end
   end
+
+  describe 'configuring capture filters' do
+    before(:each) do
+      GovukError.configuration.clear_capture_filters
+    end
+
+    it 'can accept a single capture filter' do
+      require 'govuk_app_config'
+
+      filter_helper = spy('filter_helper')
+
+      GovukError.configure do |config|
+        config.add_capture_filter do |error|
+          filter_helper.should_capture?(error)
+          true
+        end
+      end
+
+      should_capture = Raven.configuration.should_capture.call('some_error')
+
+      expect(filter_helper).to have_received(:should_capture?).with('some_error')
+      expect(should_capture).to be(true)
+    end
+
+    it 'can accept two capture filters' do
+      require 'govuk_app_config'
+
+      filter_helper = spy('filter_helper')
+
+      GovukError.configure do |config|
+        config.add_capture_filter do |error|
+          filter_helper.method1(error)
+          true
+        end
+
+        config.add_capture_filter do |error|
+          filter_helper.method2(error)
+          true
+        end
+      end
+
+      should_capture = Raven.configuration.should_capture.call('some_error')
+
+      expect(filter_helper).to have_received(:method1).with('some_error')
+      expect(filter_helper).to have_received(:method2).with('some_error')
+      expect(should_capture).to be(true)
+    end
+
+    it 'should capture when no filters are configured' do
+      require 'govuk_app_config'
+
+      should_capture = Raven.configuration.should_capture.call('some_error')
+
+      expect(should_capture).to be(true)
+    end
+
+    it 'should not capture when a filter returns false' do
+      require 'govuk_app_config'
+
+      GovukError.configure do |config|
+        config.add_capture_filter { true }
+        config.add_capture_filter { false }
+        config.add_capture_filter { true }
+      end
+
+      should_capture = Raven.configuration.should_capture.call('some_error')
+
+      expect(should_capture).to be(false)
+    end
+  end
+
+  # Reopen the class to add the ability to clear the capture filters between tests.
+  # We don't want this function available in production, because it will clear the
+  # extra capture filter applied in configure.rb, and there should never be any
+  # need to clear the filters.
+  module GovukError
+    class Configuration
+      def clear_capture_filters
+        @capture_filters = []
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sentry's Raven allows configuration of a method that determines
whether to capture errors or not: `should_capture=`. However, this
method only accepts a single `Proc` as an argument, and even then we
are already using this method in this gem in order to hook into Statsd.

In order to allow clients to use the `should_capture` method, this
change adds a `GovukError::Configuration` class, which sets up an array
of `Proc`s, which must _all_ return `true` to capture the error.