### PR TITLE
Fix `rake spec` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
 task :default => :spec


### PR DESCRIPTION
At the moment, running `rake spec` does not actually run the unit tests.
This change creates the `spec` task, so that it is run correctly by
the default Rake task.