### PR TITLE
Add `time` and `gauge` to `GovukStatsd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Add `time` and `gauge` to `GovukStatsd` 
+
 ## 0.2.0
 
 * First actual release with support for Sentry

--- a/lib/govuk_app_config/govuk_statsd.rb
+++ b/lib/govuk_app_config/govuk_statsd.rb
@@ -1,9 +1,9 @@
 require "statsd"
+require "forwardable"
 
 module GovukStatsd
-  def self.increment(*args)
-    client.increment(*args)
-  end
+  extend SingleForwardable
+  def_delegators :client, :increment, :time, :gauge
 
   def self.client
     @statsd_client ||= begin


### PR DESCRIPTION
We now delegate the methods to `client`. This means we don't have to use `GovukStatsd.client.time`, but just use `GovukStatsd.time`.