### PR TITLE
Add GovukError.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Add `time` and `gauge` to `GovukStatsd` 
+* Add `GovukError.configure` as an alias to `Raven.configure`
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you include `govuk_app_config` in your `Gemfile`, Rails' autoloading mechanis
 If you use the gem outside of Rails you'll have to explicitly require it:
 
 ```rb
-require 'govuk_app_config/configure'
+require 'govuk_app_config'
 ```
 
 Your app will have to have the following environment variables set:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ GovukError.notify(
 )
 ```
 
+### Error configuration
+
+You can exclude certain errors from being reported using this:
+
+```ruby
+GovukError.configure do |config|
+  config.excluded_exceptions << "RetryableError"
+end
+```
+
+`GovukError.configure` has the same options as the Sentry client, Raven. See [the Raven docs for all configuration options](https://docs.sentry.io/clients/ruby/config).
+
 ## License
 
 [MIT License](LICENSE.md)

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -2,7 +2,7 @@ if defined?(Airbrake)
   raise "This gem isn't compatible with Airbrake. Please remove it from the Gemfile."
 end
 
-Raven.configure do |config|
+GovukError.configure do |config|
   # We need this until https://github.com/getsentry/raven-ruby/pull/736 is released
   config.current_environment = ENV["SENTRY_CURRENT_ENV"]
 

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -10,4 +10,10 @@ module GovukError
 
     Raven.capture_exception(exception_or_message, args)
   end
+
+  def self.configure
+    Raven.configure do |config|
+      yield(config)
+    end
+  end
 end


### PR DESCRIPTION
This allows us to configure Raven without actually mentioning Raven in the code. Inspired by https://github.com/alphagov/govuk_app_config/pull/5 and [this comment](https://github.com/alphagov/content-performance-manager/pull/353/files/21e8ebfb275857387339625b68ba091fa1047c34#r140194431).

cc @alecgibson 