### PR TITLE
Configure logging using this gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-* Add Unicorn (our web server) as a dependency. Make sure to drop `gem 'unicorn'` from your Gemfile after upgrading.
+* Add Unicorn (our web server) as a dependency
 * Use version [2.7.0 of the Sentry client][sentry-270].
+* Set up logging configuration for Rails applications.
 * Don't send `ActionController::BadRequest`  to Sentry
 
 [sentry-270]: https://github.com/getsentry/raven-ruby/commit/ef623824cb0a8a2f60be5fb7e12f80454da54fd7
+
+### How to upgrade
+
+* Remove `gem 'unicorn'` from your Gemfile
+* Remove `gem 'logstasher'` from your Gemfile
+* Remove all `config.logstasher.*` configs from `config/production.rb`
 
 ## 0.3.0
 

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "statsd-ruby", "~> 1.4.0"
+  spec.add_dependency "logstasher", "~> 1.2.2"
   spec.add_dependency "sentry-raven", "~> 2.7.1"
   spec.add_dependency "unicorn", "~> 5.3.1"
 

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,4 +1,6 @@
 require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
+require "govuk_app_config/govuk_logging"
 require "govuk_app_config/configure"
+require "govuk_app_config/railtie" if defined?(Rails)

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -1,0 +1,52 @@
+# Rails applications have 2 outputs types:
+#
+# 1) Structured logging statements like the ones we create with
+# `Rails.logger.info` and Rails request logging, which we do with the logstasher
+# gem. These logs are output in JSON and can be read easily by our logging
+# stack.
+#
+# 2) The second are logs that are outputted when an exception occurs or `puts`
+# is used directly. This is unstructured text. Often this logging is sent to
+# STDOUT directly.
+#
+# We want to differentiate between the two types. To do this, we direct all log
+# statements that would _normally_ go to STDOUT to STDERR. This frees up the "real
+# stdout" for use by our loggers.
+$real_stdout = $stdout.clone
+$stdout.reopen($stderr)
+
+require 'logstasher'
+
+module GovukLogging
+  def self.configure
+    # Send Rails' logs to STDERR because they're not JSON formatted.
+    Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
+
+    # Custom that will be added to the Rails request logs
+    LogStasher.add_custom_fields do |fields|
+      # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+      fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers["SERVER_PROTOCOL"]}"
+
+      # Pass request Id to logging
+      fields[:govuk_request_id] = request.headers["GOVUK-Request-Id"]
+
+      fields[:varnish_id] = request.headers["X-Varnish"]
+
+      fields[:govuk_app_config] = GovukAppConfig::VERSION
+    end
+
+    Rails.application.config.logstasher.enabled = true
+
+    # Log controller actions so that we can graph response times
+    Rails.application.config.logstasher.controller_enabled = true
+
+    # The other loggers are not that interesting in production
+    Rails.application.config.logstasher.mailer_enabled = false
+    Rails.application.config.logstasher.record_enabled = false
+    Rails.application.config.logstasher.view_enabled = false
+    Rails.application.config.logstasher.job_enabled = false
+
+    Rails.application.config.logstasher.logger = Logger.new($real_stdout)
+    Rails.application.config.logstasher.supress_app_log = true
+  end
+end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -1,0 +1,7 @@
+module GovukAppConfig
+  class Railtie < Rails::Railtie
+    config.before_initialize do
+      GovukLogging.configure if Rails.env.production?
+    end
+  end
+end


### PR DESCRIPTION
GOV.UK applications use logstasher to output logs as JSON so they can be shipped to Kibana. 

Over the years copy-and-changing has led to a complete circus of different logging configurations. 

Here's a list of applications and versions:

Application  | Logstasher version
-- | --
asset-manager | 0.4.8
authenticating-proxy | 0.6.5
calculators | 0.6.5
calendars | 1.2.1
collections | 0.6.2
collections-publisher | 1.2.1
content-performance-manager | 1.2.1
content-store | 0.5.0
content-tagger | 1.2.1
design-principles | 0.4.8
email-alert-api | 1.2.1
feedback | 0.6.2
finder-frontend | 0.4.9
frontend | 1.1.0
government-frontend | 0.6.1
hmrc-manuals-api | 0.5.3
imminence | 0.4.8
info-frontend | 0.6.0
licence-finder | 0.6.5
link-checker-api | 0.9.0
local-links-manager | 0.6.2
manuals-frontend | 0.6.2
manuals-publisher | 0.4.8
maslow | 0.4.8
publisher | 1.2.1
publishing-api | 0.6.2
release | 0.4.8
router-api | 0.6.2
service-manual-frontend | 0.6.1
service-manual-publisher | 1.2.1
short-url-manager | 0.5.3
signon | 0.4.8
smart-answers | 0.4.8
specialist-publisher | 0.6.2
static | 0.4.8
support | 0.4.8
support-api | 0.6.2
transition | 0.6.5
travel-advice-publisher | 0.4.8
whitehall | 1.2.1

And the following apps don't use logstasher at all:

- bouncer
- contacts-admin
- email-alert-frontend
- policy-publisher
- search-admin

This PR adds logstasher as a dependency and sets up an initialiser to set it up correctly. By centralising the config we can get rid of divergent config in different apps and use the same version everywhere.

We're doing this now because we need to [bump the logstasher gem in all apps to make it work with log.it](https://github.com/alphagov/govuk-puppet/pull/6650). Moving the config into this gem now will make future upgrade processes easier.

## Todo

- [x] ~Add tests~ it's crazy hard to test this..
- [x] Add documentation
- [x] Fix logstasher crashing: https://github.com/shadabahmed/logstasher/pull/142
- [x] Test with Rails app & non-Rails apps (bouncer, rummager, email-alert-service)
