### PR TITLE
Add Unicorn as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Add Unicorn (our web server) as a dependency. Make sure to drop `gem 'unicorn'` from your Gemfile after upgrading.
+
 ## 0.3.0
 
 * Add `time` and `gauge` to `GovukStatsd`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # GOV.UK Config
 
+Adds the basics of a GOV.UK application:
+
+- Unicorn as a web server
+- Error reporting with Sentry
+- Statsd client for reporting stats
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -13,6 +19,12 @@ And then execute:
     $ bundle
 
 ## Usage
+
+## Unicorn
+
+No configuration required.
+
+## Error reporting
 
 ### Automatic error reporting
 

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "statsd-ruby", "~> 1.4.0"
   spec.add_dependency "sentry-raven", "~> 2.6.3"
+  spec.add_dependency "unicorn", "~> 5.3.1"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
All GOV.UK apps use unicorn as the web server, but we're using a wild variety of versions:

Name | Version
-- | --
asset-manager | 5.0.1
authenticating-proxy | 4.9.0
bouncer | 5.0.1
calculators | 5.0.1
calendars | 5.3.0
collections | 4.9.0
collections-publisher | 5.3.0
contacts-admin | 5.1.0
content-performance-manager | 5.3.0
content-store | 4.8.2
content-tagger | 5.0.1
design-principles | 4.3.1
email-alert-api | 5.3.0
email-alert-frontend | 5.3.0
feedback | 4.9.0
finder-frontend | 4.8.3
frontend | 4.9.0
government-frontend | 4.8.0
hmrc-manuals-api | 4.8.3
imminence | 4.3.1
info-frontend | 4.8.3
licence-finder | 5.1.0
link-checker-api | 5.3.0
local-links-manager | 4.9.0
manuals-frontend | 4.8.2
manuals-publisher | 4.8.2
maslow | 5.3.0
policy-publisher | 5.3.0
publisher | 5.3.0
publishing-api | 4.9.0
release | 4.4.0
router-api | 4.9.0
rummager | 5.1.0
search-admin | 4.9.0
service-manual-frontend | 4.8.0
service-manual-publisher | 5.3.0
short-url-manager | 5.1.0
signon | 4.9.0
smart-answers | 4.8.3
specialist-publisher | 4.9.0
static | 4.9.0
support | 4.9.0
support-api | 5.1.0
transition | 5.3.0
travel-advice-publisher | 5.0.1
whitehall | 5.3.0

This PR adds the gem as a dependency so we'll be using the same version. This will make debugging issues easier, as well as switching to a new web server like Puma.

Note that the email-alert-service isn't a web app so doesn't use a web server currently. I think it won't hurt making unicorn a dependency, for consistency's sake.