### PR TITLE
Bump sentry-raven to 2.7.1

### DIFF
--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "statsd-ruby", "~> 1.4.0"
-  spec.add_dependency "sentry-raven", "~> 2.7.0"
+  spec.add_dependency "sentry-raven", "~> 2.7.1"
   spec.add_dependency "unicorn", "~> 5.3.1"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
2.7.0 was yanked. 2.7.1 fixes the issues (https://github.com/getsentry/raven-ruby/commit/fdb16bb16d5139f6be12dd85835a5e981e0854c9).

Supersedes #13.