### PR TITLE
Ignore `ActionController::BadRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add Unicorn (our web server) as a dependency. Make sure to drop `gem 'unicorn'` from your Gemfile after upgrading.
 * Use version [2.7.0 of the Sentry client][sentry-270].
+* Don't send `ActionController::BadRequest`  to Sentry
 
 [sentry-270]: https://github.com/getsentry/raven-ruby/commit/ef623824cb0a8a2f60be5fb7e12f80454da54fd7
 

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -15,6 +15,18 @@ GovukError.configure do |config|
     true
   }
 
+  config.excluded_exceptions = [
+    'AbstractController::ActionNotFound',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionController::RoutingError',
+    'ActionController::UnknownAction',
+    'ActiveJob::DeserializationError',
+    'ActiveRecord::RecordNotFound',
+    'CGI::Session::CookieStore::TamperedWithCookie',
+    'Mongoid::Errors::DocumentNotFound',
+    'Sinatra::NotFound',
+  ]
+
   config.transport_failure_callback = Proc.new {
     GovukStatsd.increment("error_reports_failed")
   }

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -17,6 +17,7 @@ GovukError.configure do |config|
 
   config.excluded_exceptions = [
     'AbstractController::ActionNotFound',
+    'ActionController::BadRequest',
     'ActionController::InvalidAuthenticityToken',
     'ActionController::RoutingError',
     'ActionController::UnknownAction',


### PR DESCRIPTION
This happens when a client makes an invalid request to the application. There's no need for us to act on these errors.

In terms of https://github.com/alphagov/govuk-rfcs/pull/87, this is a [Bad request error](https://github.com/alphagov/govuk-rfcs/blob/errors/rfc-087-dealing-with-errors.md#bad-request-errors) and should not be sent to Sentry. In future versions of the Sentry client it might even be ignored by default: https://github.com/getsentry/raven-ruby/pull/769.

Trello: https://trello.com/c/wX66HhtR

Examples:

- https://sentry.io/govuk/app-calculators/issues/354179330
- https://sentry.io/govuk/app-government-frontend/issues/364427882