### PR TITLE
Upgrade unicorn dependency

### DIFF
--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "statsd-ruby", "~> 1.4.0"
   spec.add_dependency "logstasher", "~> 1.2.2"
   spec.add_dependency "sentry-raven", "~> 2.7.1"
-  spec.add_dependency "unicorn", "~> 5.3.1"
+  spec.add_dependency "unicorn", "~> 5.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Some apps (e.g. search-admin) are already using the latest version of unicorn.

Release notes: https://github.com/defunkt/unicorn/releases/tag/v5.4.0