### PR TITLE
Use INFO log level for unstructured logging

### DIFF
--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -20,7 +20,7 @@ require 'logstasher'
 module GovukLogging
   def self.configure
     # Send Rails' logs to STDERR because they're not JSON formatted.
-    Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
+    Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr, level: Logger::INFO))
 
     # Custom that will be added to the Rails request logs
     LogStasher.add_custom_fields do |fields|


### PR DESCRIPTION
All our applications in production should use `INFO` log level. The
default for new `Logger` instances is `DEBUG`. This is causing
applications to log multiple gig in production.