### PR TITLE
Unicorn config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Unreleased
+
+* Include a class to configure unicorn to the common GOV.UK configuration
+
+### How to upgrade
+
+* Find or create a config/unicorn.rb file in the app
+* At the top of the file insert:
+  ```rb
+  require "govuk_app_config"
+  GovukUnicorn.configure(self)
+  ```
+* If the app has the following, remove it:
+  ```rb
+  # Load the system-wide standard Unicorn file
+  def load_file_if_exists(config, file)
+    config.instance_eval(File.read(file)) if File.exist?(file)
+  end
+  load_file_if_exists(self, "/etc/govuk/unicorn.rb")
+  ```
+
 # 1.2.1
 
 * Use `INFO` log level for the default Rails logger

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ And then execute:
 
     $ bundle
 
-## Usage
 
 ## Unicorn
+
+### Configuration
 
 Find or create a `config/unicorn.rb` in the app
 
@@ -30,6 +31,14 @@ At the start of the file insert:
 ```rb
 require "govuk_app_config"
 GovukUnicorn.configure(self)
+```
+
+### Usage
+
+To serve an app with unicorn run:
+
+```sh
+$ bundle exec unicorn -c config/unicorn.rb
 ```
 
 ## Error reporting

--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ And then execute:
 
 ## Unicorn
 
-No configuration required.
+Find or create a `config/unicorn.rb` in the app
+
+At the start of the file insert:
+
+```rb
+require "govuk_app_config"
+GovukUnicorn.configure(self)
+```
 
 ## Error reporting
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adds the basics of a GOV.UK application:
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'govuk_app_config'
+gem "govuk_app_config"
 ```
 
 And then execute:
@@ -50,7 +50,7 @@ If you include `govuk_app_config` in your `Gemfile`, Rails' autoloading mechanis
 If you use the gem outside of Rails you'll have to explicitly require it:
 
 ```rb
-require 'govuk_app_config'
+require "govuk_app_config"
 ```
 
 Your app will have to have the following environment variables set:
@@ -78,9 +78,9 @@ Extra parameters are:
 ```rb
 GovukError.notify(
   "Oops",
-  extra: { offending_content_id: '123' }, # Additional context for this event. Must be a hash. Children can be any native JSON type.
-  level: 'debug', # debug, info, warning, error, fatal
-  tags: { key: 'value' } # Tags to index with this event. Must be a mapping of strings.
+  extra: { offending_content_id: "123" }, # Additional context for this event. Must be a hash. Children can be any native JSON type.
+  level: "debug", # debug, info, warning, error, fatal
+  tags: { key: "value" } # Tags to index with this event. Must be a mapping of strings.
 )
 ```
 
@@ -103,12 +103,12 @@ Use `GovukStatsd` to send stats to graphite. It has the same interface as [the R
 Examples:
 
 ```ruby
-GovukStatsd.increment 'garets'
-GovukStatsd.timing 'glork', 320
-GovukStatsd.gauge 'bork', 100
+GovukStatsd.increment "garets"
+GovukStatsd.timing "glork", 320
+GovukStatsd.gauge "bork", 100
 
 # Use {#time} to time the execution of a block
-GovukStatsd.time('account.activate') { @account.activate! }
+GovukStatsd.time("account.activate") { @account.activate! }
 ```
 
 ## Rails logging

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -2,5 +2,6 @@ require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_logging"
+require "govuk_app_config/govuk_unicorn"
 require "govuk_app_config/configure"
 require "govuk_app_config/railtie" if defined?(Rails)

--- a/lib/govuk_app_config/govuk_unicorn.rb
+++ b/lib/govuk_app_config/govuk_unicorn.rb
@@ -1,0 +1,17 @@
+module GovukUnicorn
+  def self.configure(config)
+    config.worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 2))
+
+    if ENV["GOVUK_APP_LOGROOT"]
+      config.stdout_path "#{ENV['GOVUK_APP_LOGROOT']}/app.out.log"
+      config.stderr_path "#{ENV['GOVUK_APP_LOGROOT']}/app.err.log"
+    end
+
+    config.before_exec do |server|
+      next unless ENV["GOVUK_APP_ROOT"]
+      ENV["BUNDLE_GEMFILE"] = "#{ENV['GOVUK_APP_ROOT']}/Gemfile"
+    end
+
+    config.check_client_connection true
+  end
+end


### PR DESCRIPTION
This is to provide a shared configuration for unicorn. Currently GOV.UK
apps rely on this notification to be provided by puppet through
[/etc/govuk/unicorn.rb][1] being created on each host. Then at the point
of running an app there is a [check][2] for whether a `config/unicorn.rb`
exists otherwise the puppet file will be used.

That approach has a few downsides:

1) There is code injected into the app at runtime which is not run in
other environments, notably test ones
2) There is a coupling between apps and govuk-puppet which is
unnecessary
3) It's something of an anomaly in govuk_app_config to provide a tool
(unicorn) but not it's configuration.

This approach resolves those but does have it's own downside that there
does not seem to be a way to configure unicorn automatically so apps are
required to have a config/unicorn.rb file to require the configuration.

[1]:
https://github.com/alphagov/govuk-puppet/blob/d8ca60213355704975ab655e4549069d729f15bf/modules/govuk/files/etc/govuk/unicorn.rb
[2]:
https://github.com/alphagov/govuk-puppet/blob/a6c51d887a6501f02766b7279127b60f02037a7f/modules/govuk/files/usr/local/bin/govuk_spinup#L50-L53]

Initial need for this was prompted by end-to-end tests that run the applications on unicorn but have none or partial configuration because of the puppet coupling.
