### PR TITLE
Fix spelling of "gauge" in statsd

### DIFF
--- a/lib/govuk_app_config/govuk_statsd.rb
+++ b/lib/govuk_app_config/govuk_statsd.rb
@@ -4,7 +4,7 @@ require "forwardable"
 module GovukStatsd
   extend SingleForwardable
   def_delegators :client, :increment, :decrement, :count, :time, :timing,
-    :guage, :set, :batch
+    :gauge, :set, :batch
 
   def self.client
     @statsd_client ||= begin


### PR DESCRIPTION
Engage with gauging language.

This should fix some stats reporting in the content-store: https://sentry.io/govuk/app-content-store/issues/450067775/