### PR TITLE
STDOUT woes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Move STDOUT/STDERR configuration inside GovukLogging module to reduce side
+  effects when gem is initialised.
+
 # 1.3.1
 
 * Fix collection of Statsd gauge metrics
@@ -54,13 +59,13 @@
   * If the app has any of the following (likely in `config/environments/production.rb`), remove it:
     ```rb
     # Use default logging formatter so that PID and timestamp are not suppressed.
-    config.log_formatter = ::Logger::Formatter.new		
+    config.log_formatter = ::Logger::Formatter.new
 
-    # Use a different logger for distributed setups.		
-    # require 'syslog/logger'		
-    config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))		
+    # Use a different logger for distributed setups.
+    # require 'syslog/logger'
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
 
-    $real_stdout = $stdout.clone		
+    $real_stdout = $stdout.clone
     $stdout.reopen($stderr)
     ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Unreleased
 
+* Update instructions to suggest that GovukUnicorn should be required directly
+  `require "govuk_app_config/govuk_unicorn"` rather than passively through
+  `require "govuk_app_config"` to isolate it from other configuration.
 * Move STDOUT/STDERR configuration inside GovukLogging module to reduce side
   effects when gem is initialised.
+
+### How to upgrade
+
+* In your applications `config/unicorn.rb` file change
+  `require "govuk_app_config"` to `require "govuk_app_config/govuk_unicorn"`
 
 # 1.3.1
 
@@ -16,7 +24,7 @@
 * Find or create a config/unicorn.rb file in the app
 * At the top of the file insert:
   ```rb
-  require "govuk_app_config"
+  require "govuk_app_config/govuk_unicorn"
   GovukUnicorn.configure(self)
   ```
 * If the app has the following, remove it:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Find or create a `config/unicorn.rb` in the app
 At the start of the file insert:
 
 ```rb
-require "govuk_app_config"
+require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
 ```
 

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -2,6 +2,8 @@ require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_logging"
+# This require is deprecated and should be removed on next major version bump
+# and should be required by applications directly.
 require "govuk_app_config/govuk_unicorn"
 require "govuk_app_config/configure"
 require "govuk_app_config/railtie" if defined?(Rails)

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -1,24 +1,25 @@
-# Rails applications have 2 outputs types:
-#
-# 1) Structured logging statements like the ones we create with
-# `Rails.logger.info` and Rails request logging, which we do with the logstasher
-# gem. These logs are output in JSON and can be read easily by our logging
-# stack.
-#
-# 2) The second are logs that are outputted when an exception occurs or `puts`
-# is used directly. This is unstructured text. Often this logging is sent to
-# STDOUT directly.
-#
-# We want to differentiate between the two types. To do this, we direct all log
-# statements that would _normally_ go to STDOUT to STDERR. This frees up the "real
-# stdout" for use by our loggers.
-$real_stdout = $stdout.clone
-$stdout.reopen($stderr)
 
 require 'logstasher'
 
 module GovukLogging
   def self.configure
+    # Rails applications have 2 outputs types:
+    #
+    # 1) Structured logging statements like the ones we create with
+    # `Rails.logger.info` and Rails request logging, which we do with the logstasher
+    # gem. These logs are output in JSON and can be read easily by our logging
+    # stack.
+    #
+    # 2) The second are logs that are outputted when an exception occurs or `puts`
+    # is used directly. This is unstructured text. Often this logging is sent to
+    # STDOUT directly.
+    #
+    # We want to differentiate between the two types. To do this, we direct all log
+    # statements that would _normally_ go to STDOUT to STDERR. This frees up the "real
+    # stdout" for use by our loggers.
+    $real_stdout = $stdout.clone
+    $stdout.reopen($stderr)
+
     # Send Rails' logs to STDERR because they're not JSON formatted.
     Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr, level: Logger::INFO))
 


### PR DESCRIPTION
This PR is to try address a prickly issue affecting Unicorn and Logstasher which is causing our log files to be sent to actual STDOUT rather than going into the Unicorn STDOUT log file.

To reduce risk of similar issues and streamline things I'm suggesting that the unicorn config is included by requiring the exact file. This seemed like a bit of annoying change to have as a major version breaking change so I've deprecated this so it can be handled when this Gem reaches 2.0.

Before this change:

```
➜  email-alert-api git:(logging-battle) ✗ bundle exec unicorn -c ./config/unicorn.rb
I, [2018-02-27T22:40:43.490058 #43693]  INFO -- sentry: ** [Raven] Raven 2.7.2 configured not to capture errors: DSN not set
{"method":"GET","path":"/","format":"json","controller":"welcome","action":"index","status":200,"duration":1.9,"view":0.68,"db":0.0,"ip":"127.0.0.1","route":"welcome#index","request_id":"54775f6f-5e39-4184-b697-9e46d8a9483d","request":"GET / HTTP/1.1","govuk_request_id":null,"varnish_id":null,"govuk_app_config":"1.3.1","source":"unknown","tags":["request"],"@timestamp":"2018-02-27T22:40:50.670Z","@version":"1"}
```

```
➜  /tmp wc app.out.log
       0       0       0 app.out.log
➜  /tmp wc app.err.log
      24     191    2317 app.err.log
```

After the change: 
```
➜  email-alert-api git:(logging-battle) ✗ bundle exec unicorn -c ./config/unicorn.rb
I, [2018-02-27T22:44:54.025902 #44475]  INFO -- sentry: ** [Raven] Raven 2.7.2 configured not to capture errors: DSN not set
```

```
➜  /tmp cat app.out.log
{"method":"GET","path":"/","format":"json","controller":"welcome","action":"index","status":200,"duration":2.91,"view":1.33,"db":0.0,"ip":"127.0.0.1","route":"welcome#index","request_id":"ebdef450-3745-4663-8969-134d8d4cd6fb","request":"GET / HTTP/1.1","govuk_request_id":null,"varnish_id":null,"govuk_app_config":"1.3.1","source":"unknown","tags":["request"],"@timestamp":"2018-02-27T22:44:57.160Z","@version":"1"}
➜  /tmp wc app.err.log
      23     190    2310 app.err.log
```