### PR TITLE
Count intermittent API errors instead of logging to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dev
+
+* Don't log intermittent errors from `gds-api-adapters` in Sentry, count them
+  in Graphite instead
+
 # 1.3.2
 
 * Update instructions to suggest that GovukUnicorn should be required directly


### PR DESCRIPTION
As per [GOV.UK RFC 87][rfc87], we should only log actionable errors that aren’t
intermittent. We should specify these rules in this gem.

This relies on version [52.1.0] of `gds-api-adapters`, however it’s safe to
use on older versions as we only do string matching for the exception.

[rfc87]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md
[52.1.0]: https://github.com/alphagov/gds-api-adapters/pull/813