### PR TITLE
Check the original exception if it exists for intermittent failure

### DIFF
--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -11,7 +11,8 @@ GovukError.configure do |config|
     # For backwards compatibility
     GovukStatsd.increment("errbit.errors_occurred")
 
-    if e.class.ancestors.any? { |c| c.name =~ /^GdsApi::(HTTPIntermittent|TimedOutException)/ }
+    exception_class = e.respond_to?(:original_exception) ? e.original_exception.class : e.class
+    if exception_class.ancestors.any? { |c| c.name =~ /^GdsApi::(HTTPIntermittent|TimedOutException)/ }
       GovukStatsd.increment("gds_api_adapters.errors.#{e.class.name.demodulize.underscore}")
       false
     else


### PR DESCRIPTION
If an API error occurs while processing a template, it’ll actually end
up wrapped in an `ActionView::Template::Error`. If this is the case, we
need to check the `original_exception` class instead.