### PR TITLE
Ignore ActionController::UnknownHttpMethod errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Ignore `ActionController::UnknownHttpMethod` errors.
+
 # 1.4.1
 
 * Check the inner exception as well for the intermittent failure behaviour

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -26,6 +26,7 @@ GovukError.configure do |config|
     'ActionController::InvalidAuthenticityToken',
     'ActionController::RoutingError',
     'ActionController::UnknownAction',
+    'ActionController::UnknownHttpMethod',
     'ActiveJob::DeserializationError',
     'ActiveRecord::RecordNotFound',
     'CGI::Session::CookieStore::TamperedWithCookie',


### PR DESCRIPTION
We're seeing these a lot in Whitehall for some reason, but there's no need to report the error as Rails handles it approriately.