### PR TITLE
Don't report ActionDispatch::RemoteIp::IpSpoofAttackError

### DIFF
--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -27,6 +27,7 @@ GovukError.configure do |config|
     'ActionController::RoutingError',
     'ActionController::UnknownAction',
     'ActionController::UnknownHttpMethod',
+    'ActionDispatch::RemoteIp::IpSpoofAttackError',
     'ActiveJob::DeserializationError',
     'ActiveRecord::RecordNotFound',
     'CGI::Session::CookieStore::TamperedWithCookie',


### PR DESCRIPTION
These errors are unactionable so shouldn't be reported:

https://docs.publishing.service.gov.uk/manual/errors.html#ip-spoof-errors