### PR TITLE
Add ActionController::ParameterMissing to the excluded exceptions

### DIFF
--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -24,6 +24,7 @@ GovukError.configure do |config|
     'AbstractController::ActionNotFound',
     'ActionController::BadRequest',
     'ActionController::InvalidAuthenticityToken',
+    'ActionController::ParameterMissing',
     'ActionController::RoutingError',
     'ActionController::UnknownAction',
     'ActionController::UnknownHttpMethod',


### PR DESCRIPTION
Based on the discussion in https://github.com/alphagov/whitehall/pull/3751 we can add this to the list of excluded exceptions.