### PR TITLE
Make health check endpoint set Content-Type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Set the `Content-Type` of healthchecks to `application/json`.
+
 # 1.5.0
 
 * Add healthcheck support.  See README.md for usage information.

--- a/lib/govuk_app_config/govuk_healthcheck.rb
+++ b/lib/govuk_app_config/govuk_healthcheck.rb
@@ -5,7 +5,13 @@ require "json"
 
 module GovukHealthcheck
   def self.rack_response(*checks)
-    proc { [200, {}, [JSON.dump(healthcheck(checks))]] }
+    proc do
+      [
+        200,
+        {"Content-Type" => "application/json"},
+        [JSON.dump(healthcheck(checks))]
+      ]
+    end
   end
 
   def self.healthcheck(checks)

--- a/spec/lib/govuk_healthcheck_spec.rb
+++ b/spec/lib/govuk_healthcheck_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'govuk_app_config/govuk_healthcheck'
+
+RSpec.describe GovukHealthcheck do
+  describe '#rack_response' do
+    let(:response) { described_class.rack_response.call }
+
+    it 'sets the content type' do
+      expect(response[1].fetch('Content-Type')).to eq('application/json')
+    end
+  end
+end


### PR DESCRIPTION
Since we're returning JSON on this endpoint we should set the `Content-Type` header.