### PR TITLE
Make the health check statuses symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Make the health check statuses symbols.
+
 # 1.5.0
 
 * Add healthcheck support.  See README.md for usage information.

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -1,8 +1,8 @@
 module GovukHealthcheck
   STATUSES = [
-    OK = "ok".freeze,
-    WARNING = "warning".freeze,
-    CRITICAL = "critical".freeze,
+    OK = :ok,
+    WARNING = :warning,
+    CRITICAL = :critical,
   ].freeze
 
   class Checkup


### PR DESCRIPTION
It makes more sense for them to be symbols as they should be immutable. This also provides better compatibility with the existing health check systems in various apps.