### PR TITLE
Expect health checks to be classes not instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Make health checks classes rather than instances, allowing internal data to
+  be cached and improve performance.
+
 # 1.5.1
 
 * Set the `Content-Type` of healthchecks to `application/json`.

--- a/README.md
+++ b/README.md
@@ -110,25 +110,26 @@ GovukStatsd.time("account.activate") { @account.activate! }
 Set up a route in your rack-compatible Ruby application, and pick the built-in
 or custom checks you wish to perform.
 
-Custom checks must be any class or instance which implements
+Custom checks must be a class which implements
 [this interface](spec/lib/govuk_healthcheck/shared_interface.rb):
+
 ```ruby
-module CustomCheck
-  def self.name
+class CustomCheck
+  def name
     :custom_check
   end
 
-  def self.status
+  def status
     ThingChecker.everything_okay? ? OK : CRITICAL
   end
 
   # Optional
-  def self.message
+  def message
     "This is an optional custom message"
   end
 
   # Optional
-  def self.details
+  def details
     {
       extra: "This is an optional details hash",
     }
@@ -149,6 +150,9 @@ This will check:
 - Redis connectivity (via Sidekiq)
 - Database connectivity (via ActiveRecord)
 - Your custom healthcheck
+
+Each check class gets instanced each time the health check end point is called.
+This allows you to cache any complex queries speeding up performance.
 
 ## Rails logging
 

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6.0"
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "pry"
 end

--- a/lib/govuk_app_config/govuk_healthcheck/active_record.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/active_record.rb
@@ -1,10 +1,10 @@
 module GovukHealthcheck
-  module ActiveRecord
-    def self.name
+  class ActiveRecord
+    def name
       :database_connectivity
     end
 
-    def self.status
+    def status
       ::ActiveRecord::Base.connected? ? OK : CRITICAL
     end
   end

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -20,8 +20,10 @@ module GovukHealthcheck
 
   private
 
+    attr_reader :checks
+
     def component_statuses
-      @component_statuses ||= @checks.each_with_object({}) do |check, hash|
+      @component_statuses ||= checks.each_with_object({}) do |check, hash|
         hash[check.name] = build_component_status(check)
       end
     end

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -23,7 +23,7 @@ module GovukHealthcheck
     attr_reader :checks
 
     def component_statuses
-      @component_statuses ||= checks.each_with_object({}) do |check, hash|
+      @component_statuses ||= checks.map(&:new).each_with_object({}) do |check, hash|
         hash[check.name] = build_component_status(check)
       end
     end

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
@@ -1,10 +1,10 @@
 module GovukHealthcheck
-  module SidekiqRedis
-    def self.name
+  class SidekiqRedis
+    def name
       :redis_connectivity
     end
 
-    def self.status
+    def status
       Sidekiq.redis_info ? OK : CRITICAL
     end
   end

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GovukError do
     it 'allows Airbrake-style parameters' do
       allow(Raven).to receive(:capture_exception)
 
-      error = GovukError.notify(StandardError.new, parameters: 'Something')
+      GovukError.notify(StandardError.new, parameters: 'Something')
 
       expect(Raven).to have_received(:capture_exception).with(StandardError.new, extra: { parameters: 'Something'})
     end

--- a/spec/lib/govuk_healthcheck/active_record_spec.rb
+++ b/spec/lib/govuk_healthcheck/active_record_spec.rb
@@ -4,27 +4,26 @@ require_relative "shared_interface"
 
 RSpec.describe GovukHealthcheck::ActiveRecord do
   let(:active_record) { double(:active_record, connected?: true)}
-
-  before do
-    stub_const("ActiveRecord::Base", active_record)
-  end
-
-  it_behaves_like "a healthcheck", described_class
+  before { stub_const("ActiveRecord::Base", active_record) }
 
   describe ".status" do
     context "when the database is connected" do
       let(:active_record) { double(:active_record, connected?: true)}
 
+      it_behaves_like "a healthcheck"
+
       it "returns OK" do
-        expect(described_class.status).to eq(GovukHealthcheck::OK)
+        expect(subject.status).to eq(GovukHealthcheck::OK)
       end
     end
 
     context "when the database is not connected" do
       let(:active_record) { double(:active_record, connected?: false)}
 
+      it_behaves_like "a healthcheck"
+
       it "returns CRITICAL" do
-        expect(described_class.status).to eq(GovukHealthcheck::CRITICAL)
+        expect(subject.status).to eq(GovukHealthcheck::CRITICAL)
       end
     end
   end

--- a/spec/lib/govuk_healthcheck/checkup_spec.rb
+++ b/spec/lib/govuk_healthcheck/checkup_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 require "govuk_app_config/govuk_healthcheck"
 
 RSpec.describe GovukHealthcheck::Checkup do
-  let(:ok_check) { TestHealthcheck.new(GovukHealthcheck::OK) }
-  let(:warning_check) { TestHealthcheck.new(GovukHealthcheck::WARNING) }
-  let(:critical_check) { TestHealthcheck.new(GovukHealthcheck::CRITICAL) }
+  let(:ok_check) { OkTestHealthcheck }
+  let(:warning_check) { WarningTestHealthcheck }
+  let(:critical_check) { CriticalTestHealthcheck }
 
   it "sets the overall status to the worse component status" do
     expect(described_class.new([ok_check]).run[:status]).to eq(GovukHealthcheck::OK)
@@ -27,12 +27,12 @@ RSpec.describe GovukHealthcheck::Checkup do
   end
 
   it "puts the details at the top level of each check" do
-    response = described_class.new([TestHealthcheckWithDetails.new(GovukHealthcheck::OK)]).run
+    response = described_class.new([OkTestHealthcheckWithDetails]).run
     expect(response.dig(:checks, :ok_check, :extra)).to eq("This is an extra detail")
   end
 
   it "adds the message to the check's top level if it supplies one" do
-    response = described_class.new([TestHealthcheckWithMessage.new(GovukHealthcheck::OK)]).run
+    response = described_class.new([OkTestHealthcheckWithMessage]).run
     expect(response.dig(:checks, :ok_check, :message)).to eq("This is a custom message")
   end
 
@@ -42,26 +42,36 @@ RSpec.describe GovukHealthcheck::Checkup do
   end
 
   class TestHealthcheck
-    def initialize(status)
-      @status = status
-    end
-
     def name
       "#{status}_check".to_sym
     end
+  end
 
+  class OkTestHealthcheck < TestHealthcheck
     def status
-      @status
+      :ok
     end
   end
 
-  class TestHealthcheckWithMessage < TestHealthcheck
+  class WarningTestHealthcheck < TestHealthcheck
+    def status
+      :warning
+    end
+  end
+
+  class CriticalTestHealthcheck < TestHealthcheck
+    def status
+      :critical
+    end
+  end
+
+  class OkTestHealthcheckWithMessage < OkTestHealthcheck
     def message
       "This is a custom message"
     end
   end
 
-  class TestHealthcheckWithDetails < TestHealthcheck
+  class OkTestHealthcheckWithDetails < OkTestHealthcheck
     def details
       {
         extra: "This is an extra detail",

--- a/spec/lib/govuk_healthcheck/shared_interface.rb
+++ b/spec/lib/govuk_healthcheck/shared_interface.rb
@@ -1,4 +1,6 @@
-RSpec.shared_examples "a healthcheck" do |healthcheck|
+RSpec.shared_examples "a healthcheck" do
+  let(:healthcheck) { subject }
+
   it "has a name" do
     expect(healthcheck).to respond_to(:name)
     expect(healthcheck.name).to be_a(Symbol)

--- a/spec/lib/govuk_healthcheck/sidekiq_redis_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_redis_spec.rb
@@ -4,26 +4,25 @@ require_relative "shared_interface"
 
 RSpec.describe GovukHealthcheck::SidekiqRedis do
   let(:redis_info) { double(:redis_info) }
-
-  before do
-    stub_const("Sidekiq", double(:sidekiq, redis_info: redis_info))
-  end
-
-  it_behaves_like "a healthcheck", described_class
+  before { stub_const("Sidekiq", double(:sidekiq, redis_info: redis_info)) }
 
   context "when the database is connected" do
     let(:redis_info) { double(:redis_info) }
 
+    it_behaves_like "a healthcheck"
+
     it "returns OK" do
-      expect(described_class.status).to eq(GovukHealthcheck::OK)
+      expect(subject.status).to eq(GovukHealthcheck::OK)
     end
   end
 
   context "when the database is not connected" do
     let(:redis_info) { nil }
 
+    it_behaves_like "a healthcheck"
+
     it "returns CRITICAL" do
-      expect(described_class.status).to eq(GovukHealthcheck::CRITICAL)
+      expect(subject.status).to eq(GovukHealthcheck::CRITICAL)
     end
   end
 end


### PR DESCRIPTION
While adding support for more advanced health checks in email-alert-api we switched over to using this framework provided by govuk_app_config.

One thing we've discovered is that by having health checks be a long running class instance, we can't cache any queries and a single health check could end up running the same query three times: for the status, details and message.

We could change the way health checks work and make them more complicated in email-alert-api, but I suspect this will be a problem which affects many other apps so I decided we should change the behaviour of govuk_app_config to expect health checks to be classes, which can then be instanced at the time of the request. This also follows the same behaviour of email-alert-api before it switched over to using this interface.

This is a breaking change, but since only email-alert-api uses custom checks at the moment and the interface hasn't changed for the built in checks, I think it's fine to consider it only a major update and the next release will be 1.6.0.