### PR TITLE
Bump version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.6.0
 
 * Make health checks classes rather than instances, allowing internal data to
   be cached and improve performance.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.5.1"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
The change is technically a breaking change, but I consider the health check system still in development/prototype and we may have some more future breaking changes and the number will climb high very quickly. It's currently only being used by email-alert-api, and the interface for apps which have no custom checks won't even change after this.