### PR TITLE
Health check convenience classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Add various convenience health check classes which make it easier to add
+  custom checks into apps without writing lots of code.
+
 # 1.6.0
 
 * Make health checks classes rather than instances, allowing internal data to

--- a/README.md
+++ b/README.md
@@ -105,54 +105,10 @@ GovukStatsd.gauge "bork", 100
 GovukStatsd.time("account.activate") { @account.activate! }
 ```
 
-## Healthchecks
+## Health Checks
 
-Set up a route in your rack-compatible Ruby application, and pick the built-in
-or custom checks you wish to perform.
-
-Custom checks must be a class which implements
-[this interface](spec/lib/govuk_healthcheck/shared_interface.rb):
-
-```ruby
-class CustomCheck
-  def name
-    :custom_check
-  end
-
-  def status
-    ThingChecker.everything_okay? ? OK : CRITICAL
-  end
-
-  # Optional
-  def message
-    "This is an optional custom message"
-  end
-
-  # Optional
-  def details
-    {
-      extra: "This is an optional details hash",
-    }
-  end
-end
-```
-
-For Rails apps:
-```ruby
-get "/healthcheck", to: GovukHealthcheck.rack_response(
-  GovukHealthcheck::SidekiqRedis,
-  GovukHealthcheck::ActiveRecord,
-  CustomCheck,
-)
-```
-
-This will check:
-- Redis connectivity (via Sidekiq)
-- Database connectivity (via ActiveRecord)
-- Your custom healthcheck
-
-Each check class gets instanced each time the health check end point is called.
-This allows you to cache any complex queries speeding up performance.
+This Gem provides a common "health check" framework for apps. See [the health
+check docs](docs/healthchecks.md) for more information on how to use it.
 
 ## Rails logging
 

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -43,7 +43,7 @@ It is expected that these methods may cache their results for performance
 reasons, if a user wants to ensure they have the latest value they should
 create a new instance of the check first.
 
-# Including checks in your app
+## Including checks in your app
 
 Set up a route in your rack-compatible Ruby application, and pick the built-in
 or custom checks you wish to perform.
@@ -59,6 +59,11 @@ get "/healthcheck", to: GovukHealthcheck.rack_response(
 ```
 
 ## Built-in Checks
+
+A convention used when naming these classes is that it should end with `Check`
+if it must be subclassed to work, but a concrete class which works on its own
+doesn't need that suffix. You should aim to follow this convention in your own
+apps, ideally putting custom health checks into a `Healthcheck` module.
 
 ### `SidekiqRedis`
 

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -1,19 +1,23 @@
 # Health Checks
 
-Set up a route in your rack-compatible Ruby application, and pick the built-in
-or custom checks you wish to perform.
+## Check interface
 
-Custom checks must be a class which implements
-[this interface](../spec/lib/govuk_healthcheck/shared_interface.rb):
+A check is expected to be a class with the following methods:
 
 ```ruby
 class CustomCheck
   def name
-    :custom_check
+    :the_name_of_the_check
   end
 
   def status
-    ThingChecker.everything_okay? ? OK : CRITICAL
+    if critical_condition?
+      :critical
+    elsif warning_condition?
+      :warning
+    else
+      :ok
+    end
   end
 
   # Optional
@@ -30,6 +34,15 @@ class CustomCheck
 end
 ```
 
+It is expected that these methods may cache their results for performance
+reasons, if a user wants to ensure they have the latest value they should
+create a new instance of the check first.
+
+# Including checks in your app
+
+Set up a route in your rack-compatible Ruby application, and pick the built-in
+or custom checks you wish to perform.
+
 For Rails apps:
 
 ```ruby
@@ -39,14 +52,6 @@ get "/healthcheck", to: GovukHealthcheck.rack_response(
   CustomCheck,
 )
 ```
-
-This will check:
-- Redis connectivity (via Sidekiq)
-- Database connectivity (via ActiveRecord)
-- Your custom healthcheck
-
-Each check class gets instanced each time the health check end point is called.
-This allows you to cache any complex queries speeding up performance.
 
 ## Built-in Checks
 

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -71,8 +71,7 @@ This checks that the app has a connection to the database via ActiveRecord.
 ### `ThresholdCheck`
 
 This class is the basis for a check which compares a value with a warning or a
-critical threshold. To implement this kind of check in your application, you
-can inherit from the class.
+critical threshold.
 
 ```ruby
 class MyThresholdCheck < GovukHealthcheck::ThresholdCheck
@@ -95,6 +94,40 @@ class MyThresholdCheck < GovukHealthcheck::ThresholdCheck
 
   def critical_threshold
     # if the value is above this threshold, its status is critical
+  end
+end
+```
+
+### `SidekiqQueueLatencyCheck`
+
+This class is the basis for a check which compares the Sidekiq queue latencies
+with warning or critical thresholds.
+
+```ruby
+class MySidekiqQueueLatencyCheck < GovukHealthcheck::SidekiqQueueLatencyCheck
+  def warning_threshold(queue:)
+    # the warning threshold for a particular queue
+  end
+
+  def critical_threshold(queue:)
+    # the critical threshold for a particular queue
+  end
+end
+```
+
+### `SidekiqQueueSizeCheck`
+
+This class is the basis for a check which compares the Sidekiq queue sizes
+with warning or critical thresholds.
+
+```ruby
+class MySidekiqQueueSizeCheck < GovukHealthcheck::SidekiqQueueSizeCheck
+  def warning_threshold(queue:)
+    # the warning threshold for a particular queue
+  end
+
+  def critical_threshold(queue:)
+    # the critical threshold for a particular queue
   end
 end
 ```

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -31,6 +31,11 @@ class CustomCheck
       extra: "This is an optional details hash",
     }
   end
+
+  # Optional
+  def enabled?
+    true # false if the check is not relevant at this time
+  end
 end
 ```
 

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -131,3 +131,21 @@ class MySidekiqQueueSizeCheck < GovukHealthcheck::SidekiqQueueSizeCheck
   end
 end
 ```
+
+
+### `SidekiqRetrySizeCheck`
+
+Similar to `SidekiqQueueSizeCheck`, this class is the basis for a check which
+compares the Sidekiq retry set size with a warning and critical threshold.
+
+```ruby
+class MySidekiqRetrySizeCheck < GovukHealthcheck::SidekiqRetrySizeCheck
+  def warning_threshold
+    # the warning threshold for the retry set
+  end
+
+  def critical_threshold
+    # the critical threshold for the retry set
+  end
+end
+```

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -1,0 +1,49 @@
+# Health Checks
+
+Set up a route in your rack-compatible Ruby application, and pick the built-in
+or custom checks you wish to perform.
+
+Custom checks must be a class which implements
+[this interface](../spec/lib/govuk_healthcheck/shared_interface.rb):
+
+```ruby
+class CustomCheck
+  def name
+    :custom_check
+  end
+
+  def status
+    ThingChecker.everything_okay? ? OK : CRITICAL
+  end
+
+  # Optional
+  def message
+    "This is an optional custom message"
+  end
+
+  # Optional
+  def details
+    {
+      extra: "This is an optional details hash",
+    }
+  end
+end
+```
+
+For Rails apps:
+
+```ruby
+get "/healthcheck", to: GovukHealthcheck.rack_response(
+  GovukHealthcheck::SidekiqRedis,
+  GovukHealthcheck::ActiveRecord,
+  CustomCheck,
+)
+```
+
+This will check:
+- Redis connectivity (via Sidekiq)
+- Database connectivity (via ActiveRecord)
+- Your custom healthcheck
+
+Each check class gets instanced each time the health check end point is called.
+This allows you to cache any complex queries speeding up performance.

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -47,3 +47,44 @@ This will check:
 
 Each check class gets instanced each time the health check end point is called.
 This allows you to cache any complex queries speeding up performance.
+
+## Built-in Checks
+
+### `SidekiqRedis`
+
+This checks that the app has a connection to Redis via Sidekiq.
+
+### `ActiveRecord`
+
+This checks that the app has a connection to the database via ActiveRecord.
+
+### `ThresholdCheck`
+
+This class is the basis for a check which compares a value with a warning or a
+critical threshold. To implement this kind of check in your application, you
+can inherit from the class.
+
+```ruby
+class MyThresholdCheck < GovukHealthcheck::ThresholdCheck
+  def name
+    :my_threshold_check
+  end
+
+  def value
+    # get the value to be checked
+  end
+
+  def total
+    # (optional) get the total value to be included in the details as extra
+    # information
+  end
+
+  def warning_threshold
+    # if the value is above this threshold, its status is warning
+  end
+
+  def critical_threshold
+    # if the value is above this threshold, its status is critical
+  end
+end
+```

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.6.0"
+  spec.add_development_dependency "rspec-its", "~> 1.2.0"
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/lib/govuk_app_config/govuk_healthcheck.rb
+++ b/lib/govuk_app_config/govuk_healthcheck.rb
@@ -1,6 +1,7 @@
 require "govuk_app_config/govuk_healthcheck/checkup"
 require "govuk_app_config/govuk_healthcheck/active_record"
 require "govuk_app_config/govuk_healthcheck/sidekiq_redis"
+require "govuk_app_config/govuk_healthcheck/threshold_check"
 require "json"
 
 module GovukHealthcheck

--- a/lib/govuk_app_config/govuk_healthcheck.rb
+++ b/lib/govuk_app_config/govuk_healthcheck.rb
@@ -1,10 +1,11 @@
 require "govuk_app_config/govuk_healthcheck/checkup"
 require "govuk_app_config/govuk_healthcheck/active_record"
 require "govuk_app_config/govuk_healthcheck/sidekiq_redis"
+require "govuk_app_config/govuk_healthcheck/threshold_check"
 require "govuk_app_config/govuk_healthcheck/sidekiq_queue_check"
 require "govuk_app_config/govuk_healthcheck/sidekiq_queue_latency_check"
 require "govuk_app_config/govuk_healthcheck/sidekiq_queue_size_check"
-require "govuk_app_config/govuk_healthcheck/threshold_check"
+require "govuk_app_config/govuk_healthcheck/sidekiq_retry_size_check"
 require "json"
 
 module GovukHealthcheck

--- a/lib/govuk_app_config/govuk_healthcheck.rb
+++ b/lib/govuk_app_config/govuk_healthcheck.rb
@@ -1,6 +1,9 @@
 require "govuk_app_config/govuk_healthcheck/checkup"
 require "govuk_app_config/govuk_healthcheck/active_record"
 require "govuk_app_config/govuk_healthcheck/sidekiq_redis"
+require "govuk_app_config/govuk_healthcheck/sidekiq_queue_check"
+require "govuk_app_config/govuk_healthcheck/sidekiq_queue_latency_check"
+require "govuk_app_config/govuk_healthcheck/sidekiq_queue_size_check"
 require "govuk_app_config/govuk_healthcheck/threshold_check"
 require "json"
 

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -43,9 +43,13 @@ module GovukHealthcheck
     end
 
     def build_component_status(check)
-      component_status = details(check).merge(status: check.status)
-      component_status[:message] = check.message if check.respond_to?(:message)
-      component_status
+      if check.respond_to?(:enabled?) && !check.enabled?
+        { status: :ok, message: "currently disabled" }
+      else
+        component_status = details(check).merge(status: check.status)
+        component_status[:message] = check.message if check.respond_to?(:message)
+        component_status
+      end
     end
 
     def details(check)

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_check.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_check.rb
@@ -1,0 +1,62 @@
+module GovukHealthcheck
+  class SidekiqQueueCheck
+    def status
+      queues.each do |name, value|
+        if value >= critical_threshold(queue: name)
+          return :critical
+        elsif value >= warning_threshold(queue: name)
+          return :warning
+        end
+      end
+
+      :ok
+    end
+
+    def message
+      messages = queues.map do |name, value|
+        critical = critical_threshold(queue: name)
+        warning = warning_threshold(queue: name)
+
+        if value >= critical
+          "#{name} (#{value}) is above the critical threshold (#{critical})"
+        elsif value >= warning
+          "#{name} (#{value}) is above the warning threshold (#{warning})"
+        end
+      end
+
+      messages = messages.compact
+
+      if messages.empty?
+        "all queues are below the critical and warning thresholds"
+      else
+        messages.join("\n")
+      end
+    end
+
+    def details
+      {
+        queues: queues.each_with_object({}) do |(name, value), hash|
+          hash[name] = {
+            value: value,
+            thresholds: {
+              critical: critical_threshold(queue: name),
+              warning: warning_threshold(queue: name),
+            },
+          }
+        end,
+      }
+    end
+
+    def queues
+      raise "This method must be overriden to be a hash of queue names and data."
+    end
+
+    def critical_threshold(queue:)
+      raise "This method must be overriden to be the critical threshold."
+    end
+
+    def warning_threshold(queue:)
+      raise "This method must be overriden to be the warning threshold."
+    end
+  end
+end

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_latency_check.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_latency_check.rb
@@ -1,0 +1,13 @@
+module GovukHealthcheck
+  class SidekiqQueueLatencyCheck < SidekiqQueueCheck
+    def name
+      :sidekiq_queue_latency
+    end
+
+    def queues
+      @queues ||= Sidekiq::Stats.new.queues.keys.each_with_object({}) do |name, hash|
+        hash[name] = Sidekiq::Queue.new(name).latency
+      end
+    end
+  end
+end

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_size_check.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_queue_size_check.rb
@@ -1,0 +1,11 @@
+module GovukHealthcheck
+  class SidekiqQueueSizeCheck < SidekiqQueueCheck
+    def name
+      :sidekiq_queue_size
+    end
+
+    def queues
+      @queues ||= Sidekiq::Stats.new.queues
+    end
+  end
+end

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_retry_size_check.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_retry_size_check.rb
@@ -1,0 +1,11 @@
+module GovukHealthcheck
+  class SidekiqRetrySizeCheck < ThresholdCheck
+    def name
+      :sidekiq_retry_size
+    end
+
+    def value
+      Sidekiq::Stats.new.retry_size
+    end
+  end
+end

--- a/lib/govuk_app_config/govuk_healthcheck/threshold_check.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/threshold_check.rb
@@ -1,0 +1,50 @@
+module GovukHealthcheck
+  class ThresholdCheck
+    def status
+      if value >= critical_threshold
+        :critical
+      elsif value >= warning_threshold
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def message
+      if value >= critical_threshold
+        "#{value} is above the critical threshold (#{critical_threshold})"
+      elsif value >= warning_threshold
+        "#{value} is above the warning threshold (#{warning_threshold})"
+      else
+        "#{value} is below the critical and warning thresholds"
+      end
+    end
+
+    def details
+      {
+        value: value,
+        total: total,
+        thresholds: {
+          critical: critical_threshold,
+          warning: warning_threshold,
+        },
+      }
+    end
+
+    def value
+      raise "This method must be overridden to be the check value."
+    end
+
+    def total
+      nil # This method can be overriden to provide the total for the check.
+    end
+
+    def critical_threshold
+      raise "This method must be overriden to be the critical threshold."
+    end
+
+    def warning_threshold
+      raise "This method must be overriden to be the warning threshold."
+    end
+  end
+end

--- a/spec/lib/govuk_healthcheck/shared_interface.rb
+++ b/spec/lib/govuk_healthcheck/shared_interface.rb
@@ -17,4 +17,10 @@ RSpec.shared_examples "a healthcheck" do
       expect(healthcheck.details).not_to have_key(:status)
     end
   end
+
+  it "optionally returns a `message` string" do
+    if healthcheck.respond_to?(:message)
+      expect(healthcheck.message).to be_a(String)
+    end
+  end
 end

--- a/spec/lib/govuk_healthcheck/sidekiq_queue_check_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_queue_check_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::SidekiqQueueCheck do
+  context "an ok check" do
+    subject { TestQueueCheck.new({ queue: 0 }, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:ok) }
+    its(:message) { is_expected.to match(/below the critical and warning thresholds/) }
+    its(:details) do
+      is_expected.to match(
+        queues: {
+          queue: hash_including(value: 0, thresholds: { warning: 10, critical: 20 })
+        }
+      )
+    end
+  end
+
+  context "a warning check" do
+    subject { TestQueueCheck.new({ queue: 11 }, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:warning) }
+    its(:message) { is_expected.to match(/above the warning threshold/) }
+    its(:details) do
+      is_expected.to match(
+        queues: {
+          queue: hash_including(value: 11, thresholds: { warning: 10, critical: 20 })
+        }
+      )
+    end
+  end
+
+  context "a critical check" do
+    subject { TestQueueCheck.new({ queue: 21 }, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:critical) }
+    its(:message) { is_expected.to match(/above the critical threshold/) }
+    its(:details) do
+      is_expected.to match(
+        queues: {
+          queue: hash_including(value: 21, thresholds: { warning: 10, critical: 20 })
+        }
+      )
+    end
+  end
+
+  class TestQueueCheck < GovukHealthcheck::SidekiqQueueCheck
+    def initialize(queues, warning_threshold, critical_threshold, name = :test)
+      @queues = queues
+      @warning_threshold = warning_threshold
+      @critical_threshold = critical_threshold
+      @name = name
+    end
+
+    attr_reader :queues, :name
+
+    def warning_threshold(queue:)
+      @warning_threshold
+    end
+
+    def critical_threshold(queue:)
+      @critical_threshold
+    end
+  end
+end

--- a/spec/lib/govuk_healthcheck/sidekiq_queue_latency_check_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_queue_latency_check_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::SidekiqQueueLatencyCheck do
+  subject { TestQueueLatencyCheck.new }
+
+  let(:sidekiq_stats) { double(queues: { test: 10 }) }
+  let(:sidekiq_queue) { double(latency: 5) }
+
+  let(:sidekiq_stats_class) { double }
+  let(:sidekiq_queue_class) { double }
+
+  before do
+    allow(sidekiq_stats_class).to receive(:new).and_return(sidekiq_stats)
+    allow(sidekiq_queue_class).to receive(:new).with(:test).and_return(sidekiq_queue)
+
+    stub_const("Sidekiq::Stats", sidekiq_stats_class)
+    stub_const("Sidekiq::Queue", sidekiq_queue_class)
+  end
+
+  it_behaves_like "a healthcheck"
+
+  class TestQueueLatencyCheck < GovukHealthcheck::SidekiqQueueLatencyCheck
+    def warning_threshold(queue:)
+      10
+    end
+
+    def critical_threshold(queue:)
+      20
+    end
+  end
+end

--- a/spec/lib/govuk_healthcheck/sidekiq_queue_size_check_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_queue_size_check_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::SidekiqQueueSizeCheck do
+  subject { TestQueueSizeCheck.new }
+
+  let(:sidekiq_stats) { double(queues: { test: 10 }) }
+  let(:sidekiq_stats_class) { double }
+
+  before do
+    allow(sidekiq_stats_class).to receive(:new).and_return(sidekiq_stats)
+    stub_const("Sidekiq::Stats", sidekiq_stats_class)
+  end
+
+  it_behaves_like "a healthcheck"
+
+  class TestQueueSizeCheck < GovukHealthcheck::SidekiqQueueSizeCheck
+    def warning_threshold(queue:)
+      100
+    end
+
+    def critical_threshold(queue:)
+      200
+    end
+  end
+end

--- a/spec/lib/govuk_healthcheck/sidekiq_retry_size_check_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_retry_size_check_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::SidekiqRetrySizeCheck do
+  subject { TestRetrySizeCheck.new }
+
+  let(:sidekiq_stats) { double(retry_size: 10) }
+  let(:sidekiq_stats_class) { double }
+
+  before do
+    allow(sidekiq_stats_class).to receive(:new).and_return(sidekiq_stats)
+    stub_const("Sidekiq::Stats", sidekiq_stats_class)
+  end
+
+  it_behaves_like "a healthcheck"
+
+  class TestRetrySizeCheck < GovukHealthcheck::SidekiqRetrySizeCheck
+    def warning_threshold
+      10
+    end
+
+    def critical_threshold
+      20
+    end
+  end
+end

--- a/spec/lib/govuk_healthcheck/threshold_check_spec.rb
+++ b/spec/lib/govuk_healthcheck/threshold_check_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::ThresholdCheck do
+  context "an ok check" do
+    subject { TestThresholdCheck.new(0, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:ok) }
+    its(:message) { is_expected.to match(/below the critical and warning thresholds/) }
+    its(:details) do
+      is_expected.to match(
+        hash_including(value: 0, thresholds: { warning: 10, critical: 20 })
+      )
+    end
+  end
+
+  context "a warning check" do
+    subject { TestThresholdCheck.new(11, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:warning) }
+    its(:message) { is_expected.to match(/above the warning threshold/) }
+    its(:details) do
+      is_expected.to match(
+        hash_including(value: 11, thresholds: { warning: 10, critical: 20 })
+      )
+    end
+  end
+
+  context "a critical check" do
+    subject { TestThresholdCheck.new(21, 10, 20) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:status) { is_expected.to eq(:critical) }
+    its(:message) { is_expected.to match(/above the critical threshold/) }
+    its(:details) do
+      is_expected.to match(
+        hash_including(value: 21, thresholds: { warning: 10, critical: 20 })
+      )
+    end
+  end
+
+  context "with a total" do
+    subject { TestThresholdCheck.new(0, 10, 20, 40) }
+
+    it_behaves_like "a healthcheck"
+
+    its(:details) { is_expected.to match(hash_including(total: 40)) }
+  end
+
+  class TestThresholdCheck < GovukHealthcheck::ThresholdCheck
+    def initialize(value, warning_threshold, critical_threshold, total = nil, name = :test)
+      @value = value
+      @warning_threshold = warning_threshold
+      @critical_threshold = critical_threshold
+      @total = total
+      @name = name
+    end
+
+    attr_reader :value, :warning_threshold, :critical_threshold, :total, :name
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'climate_control'
+require 'rspec/its'
 require 'webmock/rspec'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR adds a few useful health check base classes which can be used as the basis for more specific application checks. It also improves the documentation and adds the ability to disable/enable health checks during the course of an applications lifetime.

The base classes added are:
- Threshold check which compares a value (or a set of values) with a warning and a critical threshold
- Sidekiq queue size check which compares the size of individual queues with thresholds
- Sidekiq queue latency check which compares the latency of individual queues with thresholds
- Generic Sidekiq queue check which makes it easy to have a threshold check which gets applied on each queue individually

[Trello Card](https://trello.com/c/iuPQ6P88/318-add-common-parameterised-healthcheck-classes)