### PR TITLE
Handle a health check which raises an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Handle a health check which raises an exception.
+
 # 1.7.0
 
 * Add various convenience health check classes which make it easier to add

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -46,9 +46,13 @@ module GovukHealthcheck
       if check.respond_to?(:enabled?) && !check.enabled?
         { status: :ok, message: "currently disabled" }
       else
-        component_status = details(check).merge(status: check.status)
-        component_status[:message] = check.message if check.respond_to?(:message)
-        component_status
+        begin
+          component_status = details(check).merge(status: check.status)
+          component_status[:message] = check.message if check.respond_to?(:message)
+          component_status
+        rescue StandardError => e
+          { status: :critical, message: e.to_s }
+        end
       end
     end
 


### PR DESCRIPTION
This will set the status of the check to critical and include the exception in the message.

[Trello Card](https://trello.com/c/iuPQ6P88/318-add-common-parameterised-healthcheck-classes)