### PR TITLE
Stop saying errors are not going to be captured in dev

### DIFF
--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -20,6 +20,8 @@ GovukError.configure do |config|
     end
   }
 
+  config.silence_ready = !Rails.env.production? if defined?(Rails)
+
   config.excluded_exceptions = [
     'AbstractController::ActionNotFound',
     'ActionController::BadRequest',


### PR DESCRIPTION
This is useful to have logged in production, but is distracting
everywhere else.