### PR TITLE
Add GovukNodes

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,0 +1,28 @@
+# Nodes
+
+The `GovukNodes` class is used to look up hostnames for servers based on their class.
+
+This is a partial port of the script `govuk_node_list`.
+
+## Use cases
+
+In most circumstances applications shouldn't need to list servers dynamically,
+however with the migration to AWS (with its transient servers) there are some
+cases where it's necessary.
+
+The specific case this was created for is so an app on a `backend` machine can
+clear varnish caches for specific newly (re)published pages.  Because varnish
+doesn't share its cache between the different `cache` machines, this app needs
+to contact each `cache` machine directly.
+
+## Usage
+
+You can request an array of hostname strings by calling e.g.
+```ruby
+GovukNodes.of_class("cache")
+```
+
+This will return the correct list of hostnames for the environment the app is in,
+regardless of whether it is hosted on AWS or Carrenza.
+
+No further configuration is necessary.

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logstasher", "~> 1.2.2"
   spec.add_dependency "sentry-raven", "~> 2.7.1"
   spec.add_dependency "unicorn", "~> 5.4.0"
+  spec.add_dependency "aws-sdk-ec2", "~> 1"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -3,6 +3,7 @@ require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_logging"
 require "govuk_app_config/govuk_healthcheck"
+require "govuk_app_config/govuk_nodes"
 # This require is deprecated and should be removed on next major version bump
 # and should be required by applications directly.
 require "govuk_app_config/govuk_unicorn"

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -42,3 +42,7 @@ GovukError.configure do |config|
     GovukStatsd.increment("error_reports_failed")
   }
 end
+
+GovukNodes.configure do |config|
+  config.is_aws = ENV["AWS_STACKNAME"].present?
+end

--- a/lib/govuk_app_config/govuk_nodes.rb
+++ b/lib/govuk_app_config/govuk_nodes.rb
@@ -1,0 +1,41 @@
+require_relative "govuk_nodes/aws_fetcher"
+require_relative "govuk_nodes/carrenza_fetcher"
+
+class GovukNodes
+  class <<self
+    def configure
+      yield self
+    end
+
+    def aws?
+      if @is_aws.nil?
+        message = "Please configure the platform flag `is_aws` before using #{name}"
+        raise MissingConfigurationError.new(message)
+      end
+
+      @is_aws
+    end
+
+    attr_writer :is_aws
+
+    def of_class(node_class)
+      self.new.of_class(node_class)
+    end
+  end
+
+  def of_class(node_class)
+    fetcher.hostnames_of_class(node_class)
+  end
+
+private
+
+  def fetcher
+    @fetcher ||= if self.class.aws?
+      GovukNodes::AWSFetcher.new
+    else
+      GovukNodes::CarrenzaFetcher.new
+    end
+  end
+
+  class MissingConfigurationError < StandardError; end
+end

--- a/lib/govuk_app_config/govuk_nodes/aws_fetcher.rb
+++ b/lib/govuk_app_config/govuk_nodes/aws_fetcher.rb
@@ -1,0 +1,33 @@
+require "aws-sdk-ec2"
+
+class GovukNodes
+  class AWSFetcher
+    def hostnames_of_class(node_class)
+      instances_of_class(node_class).map(&:private_dns_name)
+    end
+
+  private
+
+    def ec2
+      @ec2 ||= Aws::EC2::Client.new
+    end
+
+    def stack_name
+      @stack_name ||= ENV["AWS_STACKNAME"]
+    end
+
+    def filter(name, value)
+      { name: name, values: [value] }
+    end
+
+    def instances_of_class(node_class)
+      ec2.describe_instances(
+        filters: [
+          filter("tag:aws_stackname", stack_name),
+          filter("tag:aws_migration", node_class.tr("-", "_")),
+          filter("instance-state-name", "running"),
+        ],
+      ).reservations.flat_map(&:instances)
+    end
+  end
+end

--- a/lib/govuk_app_config/govuk_nodes/carrenza_fetcher.rb
+++ b/lib/govuk_app_config/govuk_nodes/carrenza_fetcher.rb
@@ -11,7 +11,7 @@ class GovukNodes
   private
 
     def instances_of_class(node_class)
-      url = "http://puppetdb.cluster/v2/nodes?#{query_string(node_class)}"
+      url = "#{puppetdb_node_url}?#{query_string(node_class)}"
       json_response = open(url).read
       JSON.parse(json_response)
     end
@@ -21,6 +21,10 @@ class GovukNodes
       query = %{["or", ["~", ["fact", "fqdn"], "^#{hyphenated_node_class}-\\d+."]]}
 
       URI.encode_www_form(query: query)
+    end
+
+    def puppetdb_node_url
+      @puppetdb_node_url ||= ENV["PUPPETDB_NODE_URL"]
     end
   end
 end

--- a/lib/govuk_app_config/govuk_nodes/carrenza_fetcher.rb
+++ b/lib/govuk_app_config/govuk_nodes/carrenza_fetcher.rb
@@ -1,0 +1,26 @@
+require "open-uri"
+
+class GovukNodes
+  class CarrenzaFetcher
+    def hostnames_of_class(node_class)
+      instances_of_class(node_class).map do |instance|
+        instance.fetch("name")
+      end
+    end
+
+  private
+
+    def instances_of_class(node_class)
+      url = "http://puppetdb.cluster/v2/nodes?#{query_string(node_class)}"
+      json_response = open(url).read
+      JSON.parse(json_response)
+    end
+
+    def query_string(node_class)
+      hyphenated_node_class = node_class.tr("_", "-")
+      query = %{["or", ["~", ["fact", "fqdn"], "^#{hyphenated_node_class}-\\d+."]]}
+
+      URI.encode_www_form(query: query)
+    end
+  end
+end

--- a/spec/lib/govuk_nodes/aws_fetcher_spec.rb
+++ b/spec/lib/govuk_nodes/aws_fetcher_spec.rb
@@ -1,0 +1,120 @@
+require "spec_helper"
+
+require "govuk_app_config/govuk_nodes/aws_fetcher"
+
+RSpec.describe GovukNodes::AWSFetcher do
+  let(:node_class) { "email_alert_api" }
+  let(:stack_name) { "green" }
+
+  let!(:aws_client) {
+    Aws::EC2::Client.new(stub_responses: {
+      describe_instances: {
+        reservations: [
+          ec2_reservation("email_alert_api-1"),
+          ec2_reservation("email_alert_api-2"),
+        ],
+      },
+    })
+  }
+
+  let(:empty_result) {
+    Aws::EC2::Types::DescribeInstancesResult.new(reservations: [])
+  }
+
+  subject { described_class.new }
+
+  before do
+    allow(Aws::EC2::Client).to receive(:new).and_return(aws_client)
+  end
+
+  around do |example|
+    ClimateControl.modify AWS_STACKNAME: stack_name do
+      example.run
+    end
+  end
+
+  describe "#hostnames_of_class(node_class)" do
+    it "queries AWS for the nodes" do
+      expect(aws_client).to receive(:describe_instances).with(
+        filters: [
+          { name: "tag:aws_stackname", values: [stack_name] },
+          { name: "tag:aws_migration", values: [node_class] },
+          { name: "instance-state-name", values: ["running"] },
+        ]
+      ).and_return(empty_result)
+
+      subject.hostnames_of_class(node_class)
+    end
+
+    it "allows underscores or hyphens" do
+      expect(aws_client).to receive(:describe_instances).with(
+        filters: array_including(
+          { name: "tag:aws_migration", values: [node_class] },
+        )
+      ).and_return(empty_result)
+      subject.hostnames_of_class("email_alert_api")
+
+      expect(aws_client).to receive(:describe_instances).with(
+        filters: array_including(
+          { name: "tag:aws_migration", values: [node_class] },
+        )
+      ).and_return(empty_result)
+      subject.hostnames_of_class("email-alert-api")
+    end
+
+    it "returns the names of the instances found" do
+      expect(subject.hostnames_of_class(node_class)).to match_array(%w[
+        email_alert_api-1
+        email_alert_api-2
+      ])
+    end
+
+    context "when the response is a 500" do
+      let(:response_code) { 500 }
+
+      it "raises exceptions" do
+        aws_client.stub_responses(:describe_instances, {
+          status_code: response_code,
+          headers: {},
+          body: "",
+        })
+
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(Aws::Errors::ServiceError)
+      end
+    end
+
+    context "when the response is a 400" do
+      let(:response_code) { 403 }
+
+      it "raises an exception" do
+        aws_client.stub_responses(:describe_instances,
+          status_code: response_code,
+          headers: {},
+          body: "",
+        )
+
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(Aws::Errors::ServiceError)
+      end
+    end
+
+    context "when the response is a 300" do
+      let(:response_code) { 302 }
+
+      it "raises an exception" do
+        aws_client.stub_responses(:describe_instances,
+          status_code: response_code,
+          headers: {},
+          body: "",
+        )
+
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(Aws::Errors::ServiceError)
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_nodes/carrenza_fetcher_spec.rb
+++ b/spec/lib/govuk_nodes/carrenza_fetcher_spec.rb
@@ -12,28 +12,36 @@ RSpec.describe GovukNodes::CarrenzaFetcher do
   }
 
   let(:node_class) { "email-alert-api" }
+  let(:puppetdb_node_url) { "http://puppetdb.cluster/v2/nodes" }
+  let(:full_node_url) { db_url(puppetdb_node_url, node_class) }
 
   subject { described_class.new }
 
   before do
-    stub_request(:get, db_url(node_class)).to_return(
+    stub_request(:get, full_node_url).to_return(
       body: response_body,
       status: response_code,
     )
+  end
+
+  around do |example|
+    ClimateControl.modify PUPPETDB_NODE_URL: puppetdb_node_url do
+      example.run
+    end
   end
 
   describe "#hostnames_of_class(node_class)" do
     it "queries puppetdb for the nodes" do
       subject.hostnames_of_class(node_class)
 
-      expect(a_request(:get, db_url(node_class))).to have_been_made.once
+      expect(a_request(:get, full_node_url)).to have_been_made.once
     end
 
     it "allows underscores or hyphens" do
       subject.hostnames_of_class("email_alert_api")
       subject.hostnames_of_class("email-alert-api")
 
-      expect(a_request(:get, db_url(node_class))).to have_been_made.twice
+      expect(a_request(:get, full_node_url)).to have_been_made.twice
     end
 
     it "returns the names of the instances found" do

--- a/spec/lib/govuk_nodes/carrenza_fetcher_spec.rb
+++ b/spec/lib/govuk_nodes/carrenza_fetcher_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+require "govuk_app_config/govuk_nodes/carrenza_fetcher"
+
+RSpec.describe GovukNodes::CarrenzaFetcher do
+  let(:response_code) { 200 }
+  let(:response_body) {
+    [
+      puppet_instance("email_alert_api-1"),
+      puppet_instance("email_alert_api-2"),
+    ].to_json
+  }
+
+  let(:node_class) { "email-alert-api" }
+
+  subject { described_class.new }
+
+  before do
+    stub_request(:get, db_url(node_class)).to_return(
+      body: response_body,
+      status: response_code,
+    )
+  end
+
+  describe "#hostnames_of_class(node_class)" do
+    it "queries puppetdb for the nodes" do
+      subject.hostnames_of_class(node_class)
+
+      expect(a_request(:get, db_url(node_class))).to have_been_made.once
+    end
+
+    it "allows underscores or hyphens" do
+      subject.hostnames_of_class("email_alert_api")
+      subject.hostnames_of_class("email-alert-api")
+
+      expect(a_request(:get, db_url(node_class))).to have_been_made.twice
+    end
+
+    it "returns the names of the instances found" do
+      expect(subject.hostnames_of_class(node_class)).to match_array(%w[
+        email_alert_api-1
+        email_alert_api-2
+      ])
+    end
+
+    context "when the response is a 500" do
+      let(:response_body) { "" }
+      let(:response_code) { 500 }
+
+      it "raises exceptions" do
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(OpenURI::HTTPError)
+      end
+    end
+
+    context "when the response is a 400" do
+      let(:response_body) { "" }
+      let(:response_code) { 403 }
+
+      it "raises an exception" do
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(OpenURI::HTTPError)
+      end
+    end
+
+    context "when the response is a 300" do
+      let(:response_body) { "" }
+      let(:response_code) { 302 }
+
+      it "raises an exception" do
+        expect {
+          subject.hostnames_of_class(node_class)
+        }.to raise_error(OpenURI::HTTPError)
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_nodes_spec.rb
+++ b/spec/lib/govuk_nodes_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+require "govuk_app_config/govuk_nodes"
+
+RSpec.describe GovukNodes do
+  let(:node_class) { "email_alert_api" }
+
+  before do
+    described_class.is_aws = aws_flag
+  end
+
+  after do
+    described_class.is_aws = nil
+  end
+
+
+  context "if the AWS flag is not configured" do
+    let(:aws_flag) { nil }
+
+    it "raises an error" do
+      expect {
+        described_class.of_class(node_class)
+      }.to raise_error(described_class::MissingConfigurationError)
+    end
+  end
+
+  context "if the AWS flag is on" do
+    let(:aws_flag) { true }
+
+    let(:fetcher_response) {
+      %w[
+        email_alert_api-1
+      ]
+    }
+
+    it "uses the AWS fetcher" do
+      expect_any_instance_of(described_class::AWSFetcher).to receive(:hostnames_of_class)
+        .with(node_class).and_return(fetcher_response)
+
+      expect(described_class.of_class(node_class)).to eq(fetcher_response)
+    end
+  end
+
+  context "if the AWS flag is off" do
+    let(:aws_flag) { false }
+
+    let(:fetcher_response) {
+      %w[
+        email_alert_api-1
+      ]
+    }
+
+    it "uses the Carrenza fetcher" do
+      expect_any_instance_of(described_class::CarrenzaFetcher).to receive(:hostnames_of_class)
+        .with(node_class).and_return(fetcher_response)
+
+      expect(described_class.of_class(node_class)).to eq(fetcher_response)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'climate_control'
 require 'rspec/its'
 require 'webmock/rspec'
+require 'pry'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,6 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 end
+
+support_file_glob = File.expand_path(File.join(File.dirname(__FILE__), "support/**/*.rb"))
+Dir[support_file_glob].each {|f| require f}

--- a/spec/support/ec2_helper.rb
+++ b/spec/support/ec2_helper.rb
@@ -1,0 +1,25 @@
+module EC2Helper
+  # Source:
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EC2/Types/Reservation.html
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Reservation.html
+  # https://raw.githubusercontent.com/aws/aws-sdk-ruby/7f668900dd8603d6820c97779ae36ceb14c7a1ca/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
+  def ec2_reservation(instance_name)
+    {
+      instances: [ec2_instance(instance_name)],
+    }
+  end
+
+  # Source:
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EC2/Types/Instance.html
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html
+  # https://raw.githubusercontent.com/aws/aws-sdk-ruby/7f668900dd8603d6820c97779ae36ceb14c7a1ca/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
+  def ec2_instance(name)
+    {
+      private_dns_name: name,
+    }
+  end
+end
+
+RSpec.configure do |c|
+  c.include EC2Helper
+end

--- a/spec/support/puppetdb_helper.rb
+++ b/spec/support/puppetdb_helper.rb
@@ -12,10 +12,10 @@ module PuppetDBHelper
     }
   end
 
-  def db_url(node_class)
+  def db_url(base_url, node_class)
     query = '["or", ["~", ["fact", "fqdn"], "^' + node_class + '-\d+."]]'
     query_string = URI.encode_www_form(query: query)
-    "http://puppetdb.cluster/v2/nodes?#{query_string}"
+    "#{base_url}?#{query_string}"
   end
 end
 

--- a/spec/support/puppetdb_helper.rb
+++ b/spec/support/puppetdb_helper.rb
@@ -1,0 +1,24 @@
+require "uri"
+
+module PuppetDBHelper
+  # Source: https://puppet.com/docs/puppetdb/2.3/api/query/v2/nodes.html
+  def puppet_instance(name)
+    {
+      name: name,
+      deactivated: nil,
+      catalog_timestamp: Time.now.iso8601,
+      facts_timestamp: Time.now.iso8601,
+      report_timestamp: Time.now.iso8601,
+    }
+  end
+
+  def db_url(node_class)
+    query = '["or", ["~", ["fact", "fqdn"], "^' + node_class + '-\d+."]]'
+    query_string = URI.encode_www_form(query: query)
+    "http://puppetdb.cluster/v2/nodes?#{query_string}"
+  end
+end
+
+RSpec.configure do |c|
+  c.include PuppetDBHelper
+end


### PR DESCRIPTION
This provides functionality for fetching all DNS names for a given node class, regardless of whether on AWS or Carrenza.

Required for clearing varnish cache, since the `backend` machines need to issue calls directly to each `cache` box.

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish