### PR TITLE
Log, but do not throw, on missing XRay request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Make XRay log missing segments (such as when executing rake tasks)
+  as an error, rather than throwing an exception.
+
 # 1.9.0
 
 * Record 1% of requests with AWS X-Ray.

--- a/lib/govuk_app_config/govuk_xray.rb
+++ b/lib/govuk_app_config/govuk_xray.rb
@@ -15,6 +15,7 @@ module GovukXRay
     XRay.recorder.configure(
       name: ENV['GOVUK_APP_NAME'].to_s,
       patch: patch,
+      context_missing: 'LOG_ERROR',
       sampling_rules: {
         version: 1,
         default: {


### PR DESCRIPTION
If there is a problem with the instrumentation, we want to know that -
but we don't want the behaviour of the app to be affected.

The current behaviour is causing e2e test failures in frontend and whitehall.

---

[Trello card](https://trello.com/c/PFXPhBxO/451-install-default-x-ray-gem-for-rails-in-all-our-apps-mandatory-%F0%9F%8D%90)