### PR TITLE
Check for XRAY_PATCH_AWS_SDK env var, and do not patch aws_sdk if unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Only instrument the `aws_sdk` gem with AWS X-Ray if the
+  `XRAY_PATCH_AWS_SDK` environment variable is present.
+
 # 1.9.3
 
 * Do not report Sidekiq queue thresholds in healthchecks which are

--- a/lib/govuk_app_config/govuk_xray.rb
+++ b/lib/govuk_app_config/govuk_xray.rb
@@ -8,9 +8,10 @@ module GovukXRay
   end
 
   def self.start
-    # if aws-sdk is loaded, we want to instrument that too
-    patch = Gem.loaded_specs.has_key?('aws-sdk-core') ?
-              %I[aws_sdk net_http] : %I[net_http]
+    # patching 'aws_sdk' seem to impose a large memory overhead, so
+    # don't do that by default
+    patch = ENV.has_key?('XRAY_PATCH_AWS_SDK') ?
+               %I[aws_sdk net_http] : %I[net_http]
 
     # if there isn't a name set, attempting to record a segment will
     # throw an error


### PR DESCRIPTION
**I'll open an issue on aws-xray-sdk if other people agree with my conclusion.**

---

Since applying the last round of govuk_app_config upgrades, asset-manager and publishing-api have been using far more memory:

<img width="1481" alt="asset-manager" src="https://user-images.githubusercontent.com/75235/46417415-868c7400-c721-11e8-9c0f-d4809f32c536.png">
<img width="1580" alt="publishing-api" src="https://user-images.githubusercontent.com/75235/46417416-868c7400-c721-11e8-9188-db7ee6946d91.png">

The memory shoots up as soon as the app is deployed, so I believe this is an overhead imposed at initialisation-time, rather than some sort of leak which manifests when requests are made.

After doing some debugging (commenting out lines of code and crossing my fingers), I narrowed this down to having X-Ray patch the `aws_sdk` gem.  If that gem is patched, the problem occurs; if it is not, even if `net_http` is patched, the memory usage seems much closer to before.

It's a shame to lose tracking for stuff which goes through `aws_sdk`, but that's only a small amount of stuff (asset uploads from the asset-manger, and nothing(!) from the publishing-api), and I think we can assume that AWS is not the bottleneck in our architecture.

---

[Trello card](https://trello.com/c/uaiWiI51/515-investigate-increased-memory-use-of-asset-manager-and-publishing-api-since-x-ray-deploy)