### PR TITLE
Allow disabling X-Ray railtie through env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-* Disable a railtie if the environment variable
-  `GOVUK_APP_CONFIG_DISABLE_$NAME_RAILTIE` is set.  There are
-  currently two such variables:
+* Disable a feature if the environment variable
+  `GOVUK_APP_CONFIG_DISABLE_FEATURE` is set.  There are currently two
+  such variables:
 
-  * `GOVUK_APP_CONFIG_DISABLE_LOGGING_RAILTIE`
-  * `GOVUK_APP_CONFIG_DISABLE_XRAY_RAILTIE`
+  * `GOVUK_APP_CONFIG_DISABLE_LOGGING`
+  * `GOVUK_APP_CONFIG_DISABLE_XRAY`
 
 # 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
-* Disable a feature if the environment variable
-  `GOVUK_APP_CONFIG_DISABLE_FEATURE` is set.  There are currently two
-  such variables:
-
-  * `GOVUK_APP_CONFIG_DISABLE_LOGGING`
-  * `GOVUK_APP_CONFIG_DISABLE_XRAY`
+* Disable X-Ray entirely if the `GOVUK_APP_CONFIG_DISABLE_XRAY`
+  environment variable is set.
 
 # 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+* Disable a railtie if the environment variable
+  `GOVUK_APP_CONFIG_DISABLE_$NAME_RAILTIE` is set.  There are
+  currently two such variables:
+
+  * `GOVUK_APP_CONFIG_DISABLE_LOGGING_RAILTIE`
+  * `GOVUK_APP_CONFIG_DISABLE_XRAY_RAILTIE`
+
 # 1.10.0
 
 * Only instrument the `aws_sdk` gem with AWS X-Ray if the

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -5,7 +5,7 @@ module GovukAppConfig
     end
 
     config.before_initialize do
-      GovukLogging.configure if enable_railtie_for?('logging')
+      GovukLogging.configure if Rails.env.production?
     end
 
     config.after_initialize do

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -13,7 +13,7 @@ module GovukAppConfig
     end
 
     def self.enable_railtie_for?(name)
-      Rails.env.production? && !ENV.has_key?("GOVUK_APP_CONFIG_DISABLE_#{name.upcase}_RAILTIE")
+      Rails.env.production? && !ENV.has_key?("GOVUK_APP_CONFIG_DISABLE_#{name.upcase}")
     end
   end
 end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -1,16 +1,19 @@
 module GovukAppConfig
   class Railtie < Rails::Railtie
-
     initializer('govuk_app_config') do |app|
-      GovukXRay.initialize(app) if Rails.env.production?
+      GovukXRay.initialize(app) if enable_railtie_for?('xray')
     end
 
     config.before_initialize do
-      GovukLogging.configure if Rails.env.production?
+      GovukLogging.configure if enable_railtie_for?('logging')
     end
 
     config.after_initialize do
-      GovukXRay.start if Rails.env.production?
+      GovukXRay.start if enable_railtie_for?('xray')
+    end
+
+    def self.enable_railtie_for?(name)
+      Rails.env.production? && !ENV.has_key?("GOVUK_APP_CONFIG_DISABLE_#{name.upcase}_RAILTIE")
     end
   end
 end

--- a/spec/lib/railtie_spec.rb
+++ b/spec/lib/railtie_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+# dummy classes which Govuk::Railtie needs
+module GovukAppConfig
+  class Rails
+    def self.env; end
+  end
+
+  class Rails::DummyConfig
+    def self.after_initialize(&_blk); end
+
+    def self.before_initialize(&_blk); end
+  end
+
+  class Rails::Railtie
+    def self.initializer(_name, &_blk); end
+
+    def self.config
+      Rails::DummyConfig
+    end
+  end
+end
+
+require 'govuk_app_config/railtie'
+
+RSpec.describe GovukAppConfig::Railtie do
+  let(:production) { instance_double('production') }
+  let(:not_production) { instance_double('not production') }
+
+  before do
+    allow(production).to receive(:production?) { true }
+    allow(not_production).to receive(:production?) { false }
+  end
+
+  describe '#enable_railtie_for?' do
+    context 'GOVUK_APP_CONFIG_DISABLE_name_RAILTIE is unset' do
+      it 'returns true if in production' do
+        allow(GovukAppConfig::Rails).to receive(:env) { production }
+        expect(described_class.enable_railtie_for?('foo')).to eql(true)
+      end
+
+      it 'returns false if not in production' do
+        allow(GovukAppConfig::Rails).to receive(:env) { not_production }
+        expect(described_class.enable_railtie_for?('foo')).to eql(false)
+      end
+    end
+
+    context 'GOVUK_APP_CONFIG_DISABLE_name_RAILTIE is set' do
+      it 'returns false if in production' do
+        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO_RAILTIE: 'i am set' do
+          allow(GovukAppConfig::Rails).to receive(:env) { production }
+          expect(described_class.enable_railtie_for?('foo')).to eql(false)
+        end
+      end
+
+      it 'returns false if not in production' do
+        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO_RAILTIE: 'i am set' do
+          allow(GovukAppConfig::Rails).to receive(:env) { not_production }
+          expect(described_class.enable_railtie_for?('foo')).to eql(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/railtie_spec.rb
+++ b/spec/lib/railtie_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe GovukAppConfig::Railtie do
   end
 
   describe '#enable_railtie_for?' do
-    context 'GOVUK_APP_CONFIG_DISABLE_name_RAILTIE is unset' do
+    context 'GOVUK_APP_CONFIG_DISABLE_name is unset' do
       it 'returns true if in production' do
         allow(GovukAppConfig::Rails).to receive(:env) { production }
         expect(described_class.enable_railtie_for?('foo')).to eql(true)
@@ -45,16 +45,16 @@ RSpec.describe GovukAppConfig::Railtie do
       end
     end
 
-    context 'GOVUK_APP_CONFIG_DISABLE_name_RAILTIE is set' do
+    context 'GOVUK_APP_CONFIG_DISABLE_name is set' do
       it 'returns false if in production' do
-        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO_RAILTIE: 'i am set' do
+        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO: 'i am set' do
           allow(GovukAppConfig::Rails).to receive(:env) { production }
           expect(described_class.enable_railtie_for?('foo')).to eql(false)
         end
       end
 
       it 'returns false if not in production' do
-        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO_RAILTIE: 'i am set' do
+        ClimateControl.modify GOVUK_APP_CONFIG_DISABLE_FOO: 'i am set' do
           allow(GovukAppConfig::Rails).to receive(:env) { not_production }
           expect(described_class.enable_railtie_for?('foo')).to eql(false)
         end


### PR DESCRIPTION
The setting up of dummy classes for the test code is a bit unpleasant.