### PR TITLE
Enable initialized health check classes

### DIFF
--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -58,6 +58,14 @@ get "/healthcheck", to: GovukHealthcheck.rack_response(
 )
 ```
 
+It also accepts objects, so classes can be initialized:
+
+```ruby
+get "/healthcheck", to: GovukHealthcheck.rack_response(
+  InitializedCheck.new(:param),
+)
+```
+
 ## Built-in Checks
 
 A convention used when naming these classes is that it should end with `Check`

--- a/lib/govuk_app_config/govuk_healthcheck/checkup.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/checkup.rb
@@ -23,9 +23,13 @@ module GovukHealthcheck
     attr_reader :checks
 
     def component_statuses
-      @component_statuses ||= checks.map(&:new).each_with_object({}) do |check, hash|
+      @component_statuses ||= all_components.each_with_object({}) do |check, hash|
         hash[check.name] = build_component_status(check)
       end
+    end
+
+    def all_components
+      checks.map { |check| check.instance_of?(Class) ? check.new : check }
     end
 
     def worst_status

--- a/spec/lib/govuk_healthcheck/checkup_spec.rb
+++ b/spec/lib/govuk_healthcheck/checkup_spec.rb
@@ -63,9 +63,18 @@ RSpec.describe GovukHealthcheck::Checkup do
     expect(response.dig(:checks, :critical_check, :status)).to eq(:ok)
   end
 
+  it "accepts objects (can be initialized)" do
+    response = described_class.new([TestHealthcheck.new]).run
+    expect(response.dig(:checks, :unknown_check, :status)).to eq(:unknown)
+  end
+
   class TestHealthcheck
     def name
       "#{status}_check".to_sym
+    end
+
+    def status
+      :unknown
     end
   end
 


### PR DESCRIPTION
Adds support for adding parametrized classes for the health check chain:

```ruby
get "/healthcheck", to: GovukHealthcheck.rack_response(
  GovukHealthcheck::SidekiqRedis,
  GovukHealthcheck::ActiveRecord,
  GovukHealthcheck::InitializedCheck.new(:param),
)
```

Enable applications to reuse the same Check without being forced
to use inheritance or other mechanisms.

This is introduced in https://github.com/alphagov/content-performance-manager/pull/1131/commits/73aec09c289f785c06040845662c61a7f4d163e1, and is part of PR https://github.com/alphagov/content-performance-manager/pull/1131. We aim to reuse the same check for multiple metrics.