### PR TITLE
Make ActiveRecord healthcheck less flakey

### DIFF
--- a/lib/govuk_app_config/govuk_healthcheck/active_record.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/active_record.rb
@@ -5,7 +5,10 @@ module GovukHealthcheck
     end
 
     def status
-      ::ActiveRecord::Base.connected? ? OK : CRITICAL
+      ::ActiveRecord::Base.connection
+      OK
+    rescue StandardError => e
+      CRITICAL
     end
   end
 end

--- a/spec/lib/govuk_healthcheck/active_record_spec.rb
+++ b/spec/lib/govuk_healthcheck/active_record_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GovukHealthcheck::ActiveRecord do
 
   describe ".status" do
     context "when the database is connected" do
-      let(:active_record) { double(:active_record, connected?: true)}
+      let(:active_record) { double(:active_record, connection: true) }
 
       it_behaves_like "a healthcheck"
 
@@ -18,7 +18,11 @@ RSpec.describe GovukHealthcheck::ActiveRecord do
     end
 
     context "when the database is not connected" do
-      let(:active_record) { double(:active_record, connected?: false)}
+      let(:active_record) { double(:active_record, connection: true) }
+
+      before do
+        allow(active_record).to receive(:connection) { raise }
+      end
 
       it_behaves_like "a healthcheck"
 


### PR DESCRIPTION
Previously the AR healthcheck used to call '.connected?' and return a
status based on the boolean return value. But if the app is not being
used much, then the connection pool may be empty as all the idle
connections will have been removed. This changes the approach to
explicitly requests a connection if it doesn't already exist, which
means we should have less false negatives for low-traffic apps.