### PR TITLE
Remove formatting from the logstasher logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Remove formating from the Logstasher logger, used by default for the
+  GDS API Adapters logging.
+
 # 1.13.0
 
 * Configure the GDS API Adapters logger to use logstasher

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -48,7 +48,10 @@ module GovukLogging
 
     Rails.application.config.logstasher.logger = Logger.new(
       $real_stdout,
-      level: Rails.logger.level
+      level: Rails.logger.level,
+      formatter: proc { |_severity, _datetime, _progname, msg|
+        "#{String === msg ? msg : msg.inspect}\n"
+      }
     )
     Rails.application.config.logstasher.supress_app_log = true
 


### PR DESCRIPTION
This logger is now used by GDS API Adapters by default, but it
includes the default metadata, so the resulting output isn't valid
JSON.

Therefore, change the formatter so that it's just the message that's
logged.