### PR TITLE
Release version 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.13.1
 
 * Remove formating from the Logstasher logger, used by default for the
   GDS API Adapters logging.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.13.0"
+  VERSION = "1.13.1"
 end


### PR DESCRIPTION
This includes one change, to remove formating from the Logstasher
logger, used by default for the GDS API Adapters logging.