### PR TITLE
Allow configuring the unicorn timeout

### DIFF
--- a/lib/govuk_app_config/govuk_unicorn.rb
+++ b/lib/govuk_app_config/govuk_unicorn.rb
@@ -2,6 +2,8 @@ module GovukUnicorn
   def self.configure(config)
     config.worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 2))
 
+    config.timeout = Integer(ENV.fetch("UNICORN_TIMEOUT", 60))
+
     if ENV["GOVUK_APP_LOGROOT"]
       config.stdout_path "#{ENV['GOVUK_APP_LOGROOT']}/app.out.log"
       config.stderr_path "#{ENV['GOVUK_APP_LOGROOT']}/app.err.log"


### PR DESCRIPTION
Unicorn has a default timeout of 60s, nginx has a different timeout.
We should make the unicorn timeout configurable so that it can match
nginx.

Unicorn recommends some additional nginx configuration if changing its
timeout:

> For running Unicorn behind nginx, it is recommended to set
> “fail_timeout=0” for in your nginx configuration like this to have
> nginx always retry backends that may have had workers SIGKILL-ed due
> to timeouts.

---

[Trello card](https://trello.com/c/XUgnpLbM/119-action-item-fix-unicorn-worker-timeout)