### PR TITLE
Unicorn config.timeout is a method, not an lvalue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fix the `UNICORN_TIMEOUT` setting, which previously resulted in a
+  crash on start.
+
 # 1.15.0
 
 * Allow configuring the unicorn timeout through the `UNICORN_TIMEOUT`

--- a/lib/govuk_app_config/govuk_unicorn.rb
+++ b/lib/govuk_app_config/govuk_unicorn.rb
@@ -2,7 +2,7 @@ module GovukUnicorn
   def self.configure(config)
     config.worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 2))
 
-    config.timeout = Integer(ENV.fetch("UNICORN_TIMEOUT", 60))
+    config.timeout Integer(ENV.fetch("UNICORN_TIMEOUT", 60))
 
     if ENV["GOVUK_APP_LOGROOT"]
       config.stdout_path "#{ENV['GOVUK_APP_LOGROOT']}/app.out.log"


### PR DESCRIPTION
https://www.rubydoc.info/gems/unicorn/Unicorn/Configurator#timeout-instance_method