### PR TITLE
Add stats.g.doubleclick.net as a Google Analytics domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add a DoubleClick domain to our content security policy.
+
 # 1.15.1
 
 * Fix the `UNICORN_TIMEOUT` setting, which previously resulted in a

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -13,7 +13,7 @@ module GovukContentSecurityPolicy
 
   GOVUK_DOMAINS = "'self' *.publishing.service.gov.uk localhost".freeze
 
-  GOOGLE_ANALYTICS_DOMAINS = "www.google-analytics.com ssl.google-analytics.com".freeze
+  GOOGLE_ANALYTICS_DOMAINS = "www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net".freeze
 
   def self.build
     policies = []


### PR DESCRIPTION
Smokey is currently failing because pages in Licensify include a doubleclick tracking image. We need to include this domain to our content security policy to make sure that we don't block access to that domain.

```
Feature: Licensing
  Tests for the Licensify app.

  @normal @notintegration
  Scenario: Check licensing app is present    # features/licensing.feature:5
    Given I am testing "licensing" internally # features/step_definitions/smokey_steps.rb:11
    And I am testing through the full stack   # features/step_definitions/smokey_steps.rb:19
    And I force a varnish cache miss          # features/step_definitions/smokey_steps.rb:26
    Then I should be able to visit:           # features/step_definitions/smokey_steps.rb:120
      | Path                                                       |
      | /apply-for-a-licence/test-licence/westminster/apply-1      |
      | /apply-for-a-licence/test-licence/westminster/apply-1/form |
      | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1  |📜   severe 
     https://www.gov.uk/apply-for-a-licence/test-licence/westminster/apply-1?cachebust=0.8574050796764224 - Refused to load the image 'https://stats.g.doubleclick.net/r/collect?v=1&aip=1&t=dc&_r=3&tid=UA-26179049-1&cid=1133215272.1556286423&jid=337536354&_gid=788058208.1556286423&gjid=2146529473&_v=j73&z=82427798' because it violates the following Content Security Policy directive: "img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com".
```

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)