### PR TITLE
Return critical status for Redis connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Return Critical status for SidekiqRedis if Redis raises a connection error.
+
 # 1.16.0
 
 * Add a DoubleClick domain to our content security policy.

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
@@ -6,6 +6,11 @@ module GovukHealthcheck
 
     def status
       Sidekiq.redis_info ? OK : CRITICAL
+
+    rescue StandardError
+      # One would expect a Redis::BaseConnectionError, but this should be
+      # critical if any exception is raised when making a call to redis.
+      CRITICAL
     end
   end
 end

--- a/spec/lib/govuk_healthcheck/sidekiq_redis_spec.rb
+++ b/spec/lib/govuk_healthcheck/sidekiq_redis_spec.rb
@@ -4,7 +4,8 @@ require_relative "shared_interface"
 
 RSpec.describe GovukHealthcheck::SidekiqRedis do
   let(:redis_info) { double(:redis_info) }
-  before { stub_const("Sidekiq", double(:sidekiq, redis_info: redis_info)) }
+  let(:sidekiq) { double(:sidekiq, redis_info: redis_info) }
+  before { stub_const("Sidekiq", sidekiq) }
 
   context "when the database is connected" do
     let(:redis_info) { double(:redis_info) }
@@ -22,6 +23,14 @@ RSpec.describe GovukHealthcheck::SidekiqRedis do
     it_behaves_like "a healthcheck"
 
     it "returns CRITICAL" do
+      expect(subject.status).to eq(GovukHealthcheck::CRITICAL)
+    end
+  end
+
+  context "when redis raises a connection error" do
+    it "returns CRITICAL" do
+      allow(sidekiq).to receive(:redis_info).and_raise StandardError
+
       expect(subject.status).to eq(GovukHealthcheck::CRITICAL)
     end
   end


### PR DESCRIPTION
Redis raises a connection error if it's not available so this will catch those. I used StandardError so that it will be raised regardless if `Redis` exists in the application this is used.