### PR TITLE
Change context_missing error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Don't log Context Missing Errors (`ERROR -- : can not find the current context.`)
+
 # 1.16.1
 
 * Return Critical status for SidekiqRedis if Redis raises a connection error.

--- a/lib/govuk_app_config/govuk_xray.rb
+++ b/lib/govuk_app_config/govuk_xray.rb
@@ -21,7 +21,7 @@ module GovukXRay
     XRay.recorder.configure(
       name: name,
       patch: patch,
-      context_missing: 'LOG_ERROR',
+      context_missing: 'IGNORE_ERROR',
       sampling_rules: {
         version: 1,
         default: {


### PR DESCRIPTION
This will remove persistent logging of `ERROR -- : can not find the current context.` from our logs.

This is from the aws-xray-sdk-ruby gem. Changing the log level in this way seems to have no side effects.

See: https://github.com/aws/aws-xray-sdk-ruby/blob/5134f203a0a0c7681e137aa6045ad64fc645c8fe/lib/aws-xray-sdk/context/default_context.rb#L62