### PR TITLE
Tweak our CSP to work with 'dev.gov.uk'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Tweak our CSP to work with 'dev.gov.uk'
+
 # 1.16.3
 
 * Revert PR #89 - it relies on an unreleased feature of aws-xray-sdk

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -11,7 +11,11 @@ module GovukContentSecurityPolicy
   # - https://csp-evaluator.withgoogle.com
   # - https://cspvalidator.org
 
-  GOVUK_DOMAINS = "'self' *.publishing.service.gov.uk localhost".freeze
+  GOVUK_DOMAINS = [
+    "'self'",
+    '*.publishing.service.gov.uk',
+    "*.#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}"
+  ].uniq.join(" ").freeze
 
   GOOGLE_ANALYTICS_DOMAINS = "www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net".freeze
 
@@ -130,9 +134,9 @@ module GovukContentSecurityPolicy
     # AWS Lambda function that filters out junk reports.
     if Rails.env.production?
       reporting = "report-uri https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production"
-      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy-Report-Only'] = GovukContentSecurityPolicy.build + " " + reporting
+      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy-Report-Only'] = self.build + " " + reporting
     else
-      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy'] = GovukContentSecurityPolicy.build
+      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy'] = self.build
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/j7mUrNuO/883-fix-csp-breaking-apps-in-development-environment

    Previously our Content Security Policy (CSP) disallowed content from
    our own apps when run in development with the 'dev.gov.uk' domain. Our
    frontend apps rely on externals assets (e.g. from static.dev.gov.uk)
    and these are not allowed under the current policy.
    
    We also hardcode some assets, such as 'placeholder.png' to be served
    from the production assets domain. This means that we should allow for
    both 'dev.gov.uk' and 'publishing.service.gov.uk' in development. But we
    should avoid implicitly trusting 'dev.gov.uk' outside of development.
    
    This also removes 'localhost' from all policies, as it should normally
    be covered by 'self', which applies to content requested from the same
    domain and port. It would impact running connecting multiple apps on
    localhost with different ports, but there's no clear need to do this.

<img width="1552" alt="Screen Shot 2019-05-22 at 13 30 44" src="https://user-images.githubusercontent.com/9029009/58184352-d7e57580-7ca8-11e9-998a-c6addad7b4e8.png">
