### PR TITLE
Use Rails DSL for CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Use Rails DSL to configure content security policy, allowing apps to modify
+  the policy and use nonce features.
+
 # 1.17.0
 
 * Tweak our CSP to work with 'dev.gov.uk'

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "unicorn", "~> 5.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "rails", "~> 5"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.6.0"
   spec.add_development_dependency "rspec-its", "~> 1.2.0"

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,5 +1,4 @@
 require "govuk_app_config/version"
-require "govuk_app_config/govuk_content_security_policy"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_logging"
@@ -9,4 +8,8 @@ require "govuk_app_config/govuk_healthcheck"
 require "govuk_app_config/govuk_unicorn"
 require "govuk_app_config/govuk_xray"
 require "govuk_app_config/configure"
-require "govuk_app_config/railtie" if defined?(Rails)
+
+if defined?(Rails)
+  require "govuk_app_config/railtie"
+  require "govuk_app_config/govuk_content_security_policy"
+end

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -69,7 +69,7 @@ module GovukContentSecurityPolicy
     policy.object_src :none
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
-    policy.frame_src "www.youtube.com" # Allow youtube embeds
+    policy.frame_src :self, *GOVUK_DOMAINS, "www.youtube.com" # Allow youtube embeds
 
     # AWS Lambda function that filters out junk reports.
     policy.report_uri = "https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production" if Rails.env.production?

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -1,9 +1,6 @@
 module GovukContentSecurityPolicy
   # Generate a Content Security Policy (CSP) directive.
   #
-  #
-  # Extracted in a separate module to allow comments.
-  #
   # See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more CSP info.
   #
   # The resulting policy should be checked with:
@@ -12,131 +9,75 @@ module GovukContentSecurityPolicy
   # - https://cspvalidator.org
 
   GOVUK_DOMAINS = [
-    "'self'",
     '*.publishing.service.gov.uk',
     "*.#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}"
-  ].uniq.join(" ").freeze
+  ].uniq.freeze
 
-  GOOGLE_ANALYTICS_DOMAINS = "www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net".freeze
+  GOOGLE_ANALYTICS_DOMAINS = %w(www.google-analytics.com
+                                ssl.google-analytics.com
+                                stats.g.doubleclick.net).freeze
 
-  def self.build
-    policies = []
-
-    # By default, only allow HTTPS connections, and allow loading things from
-    # the publishing domain
-    #
+  def self.build_policy(policy)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
-    policies << [
-      "default-src https",
-      GOVUK_DOMAINS
-    ]
+    policy.default_src :https, :self, *GOVUK_DOMAINS
 
-    # Allow images from the current domain, Google Analytics (the tracking pixel),
-    # and publishing domains.
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
-    policies << [
-      "img-src",
+    policy.img_src :self,
+                   :data, # Base64 encoded images
+                   *GOVUK_DOMAINS,
+                   *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
+                   # Some content still links to an old domain we used to use
+                   "assets.digital.cabinet-office.gov.uk"
 
-      # Allow `data:` images for Base64-encoded images in CSS like:
-      #
-      # https://github.com/alphagov/service-manual-frontend/blob/1db99ed48de0dfc794b9686a98e6c62f8435ae80/app/assets/stylesheets/modules/_search.scss#L106
-      "data:",
-
-      GOVUK_DOMAINS,
-      GOOGLE_ANALYTICS_DOMAINS,
-
-      # Some content still links to an old domain we used to use
-      "assets.digital.cabinet-office.gov.uk",
-    ]
-
-    # script-src determines the scripts that the browser can load
-    #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
-    policies << [
-      # Allow scripts from publishing domains
-      "script-src",
-      GOVUK_DOMAINS,
-      GOOGLE_ANALYTICS_DOMAINS,
+    policy.script_src :self,
+                      *GOVUK_DOMAINS,
+                      *GOOGLE_ANALYTICS_DOMAINS,
+                      # Allow JSONP call to Verify to check whether the user is logged in
+                      "www.signin.service.gov.uk",
+                      # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
+                      "*.ytimg.com",
+                      "www.youtube.com",
+                      # Allow all inline scripts until we can conclusively
+                      # document all the inline scripts we use,
+                      # and there's a better way to filter out junk reports
+                      :unsafe_inline
 
-      # Allow JSONP call to Verify to check whether the user is logged in
-      # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
-      # https://github.com/alphagov/government-frontend/blob/71aca4df9b74366618a5a93acdb5cd2715f94f49/app/assets/javascripts/modules/track-radio-group.js
-      "www.signin.service.gov.uk",
-
-      # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
-      "*.ytimg.com",
-      "www.youtube.com",
-
-      # Allow all inline scripts until we can conclusively document all the inline scripts we use,
-      # and there's a better way to filter out junk reports
-      "'unsafe-inline'"
-    ]
-
-    # Allow styles from own domain and publishing domains.
-    #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
-    policies << [
-      "style-src",
-      GOVUK_DOMAINS,
+    policy.style_src :self,
+                     *GOVUK_DOMAINS,
+                     # We use the `style=""` attribute on some HTML elements
+                     :unsafe_inline
 
-      # Also allow "unsafe-inline" styles, because we use the `style=""` attribute on some HTML elements
-      "'unsafe-inline'"
-    ]
-
-    # Allow fonts to be loaded from data-uri's (this is the old way of doing things)
-    # or from the publishing asset domains.
-    #
-    # https://www.staging.publishing.service.gov.uk/apply-for-a-licence/test-licence/westminster/apply-1
-    #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
-    policies << [
-      "font-src data:",
-      GOVUK_DOMAINS
-    ]
+    policy.font_src :self,
+                    *GOVUK_DOMAINS,
+                    :data # Used by some legacy fonts
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
-    policies << [
-      # Scripts can only load data using Ajax from Google Analytics and the publishing domains
-      "connect-src",
-      GOVUK_DOMAINS,
-      GOOGLE_ANALYTICS_DOMAINS,
-
-      # Allow connecting to web chat from HMRC contact pages like
-      # https://www.staging.publishing.service.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit
-      "www.tax.service.gov.uk",
-
-      # Allow connecting to Verify to check whether the user is logged in
-      # https://github.com/alphagov/government-frontend/blob/71aca4df9b74366618a5a93acdb5cd2715f94f49/app/assets/javascripts/modules/track-radio-group.js
-      # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
-      "www.signin.service.gov.uk",
-    ]
+    policy.connect_src :self,
+                       *GOVUK_DOMAINS,
+                       *GOOGLE_ANALYTICS_DOMAINS,
+                       # Allow connecting to web chat from HMRC contact pages
+                       "www.tax.service.gov.uk",
+                       # Allow connecting to Verify to check whether the user is logged in
+                       "www.signin.service.gov.uk"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
-    policies << [
-      "object-src 'none'"
-    ]
+    policy.object_src :none
 
-    policies << [
-      "frame-src",
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
+    policy.frame_src "www.youtube.com" # Allow youtube embeds
 
-      # Allow YouTube embeds
-      "www.youtube.com",
-    ]
-
-    policies.map { |str| str.join(" ") }.join("; ") + ";"
+    # AWS Lambda function that filters out junk reports.
+    policy.report_uri = "https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production" if Rails.env.production?
   end
 
   def self.configure
-    # In test and development, use CSP for real to find issues. In production we only
-    # report violations to Sentry (https://sentry.io/govuk/govuk-frontend-csp) via an
-    # AWS Lambda function that filters out junk reports.
-    if Rails.env.production?
-      reporting = "report-uri https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production"
-      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy-Report-Only'] = self.build + " " + reporting
-    else
-      Rails.application.config.action_dispatch.default_headers['Content-Security-Policy'] = self.build
-    end
+    Rails.application.config.content_security_policy_report_only = true if Rails.env.production?
+
+    Rails.application.config.content_security_policy(&method(:build_policy))
   end
 end

--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'rails'
+require 'govuk_app_config/govuk_content_security_policy'
+
+RSpec.describe GovukContentSecurityPolicy do
+  class DummyCspRailsApp < Rails::Application; end
+
+  describe '.configure' do
+    it 'creates a policy' do
+      Rails.application.config.content_security_policy = nil
+
+      expect { GovukContentSecurityPolicy.configure }
+        .to change { Rails.application.config.content_security_policy }
+        .to(an_instance_of(ActionDispatch::ContentSecurityPolicy))
+    end
+
+    it 'returns a policy' do
+      expect(GovukContentSecurityPolicy.configure)
+        .to be_a(ActionDispatch::ContentSecurityPolicy)
+    end
+  end
+end


### PR DESCRIPTION
This is built off https://github.com/alphagov/govuk_app_config/pull/90 with the expectation that will be merged first.

This refactors the CSP to use the Rails DSL, this is backwards
compatible with the previous implementation. This refactor provides a few
benefits:

- no longer needs to set up the actual policy, just configuration
  needed;
- apps can add/remove things to the policy if needed;
- the nonce generator allows setting a nonce on inline javascript tags

I've reduced the amount of comments in this file for brevity. A lot of
the example URLs felt unnecessary for the source code and felt more like they
belonged in a commit message.