### PR TITLE
Revert the Xray IGNORE_ERROR change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.16.3
+
+* Revert PR #89 - it relies on an unreleased feature of aws-xray-sdk
+
 # 1.16.2
 
 * Don't log Context Missing Errors (`ERROR -- : can not find the current context.`)

--- a/lib/govuk_app_config/govuk_xray.rb
+++ b/lib/govuk_app_config/govuk_xray.rb
@@ -21,7 +21,7 @@ module GovukXRay
     XRay.recorder.configure(
       name: name,
       patch: patch,
-      context_missing: 'IGNORE_ERROR',
+      context_missing: 'LOG_ERROR',
       sampling_rules: {
         version: 1,
         default: {

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.16.2"
+  VERSION = "1.16.3"
 end


### PR DESCRIPTION
This change used a config option for Xray that silenced errors:
https://github.com/aws/aws-xray-sdk-ruby/pull/18 however this option has
not been released in the most recent version of the gem 0.11.1 and
besides that this project is tied to use 0.10 of that gem.