### PR TITLE
Fix report_uri CSP DSL method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.18.1
+
+* Fix incorrect report_uri= method usage in content security policy
+
 # 1.18.0
 
 * Use Rails DSL to configure content security policy, allowing apps to modify

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -72,7 +72,7 @@ module GovukContentSecurityPolicy
     policy.frame_src :self, *GOVUK_DOMAINS, "www.youtube.com" # Allow youtube embeds
 
     # AWS Lambda function that filters out junk reports.
-    policy.report_uri = "https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production" if Rails.env.production?
+    policy.report_uri "https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production" if Rails.env.production?
   end
 
   def self.configure

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.18.0"
+  VERSION = "1.18.1"
 end


### PR DESCRIPTION
Argh embarrassing fix alert.

Turns out the report_uri isn't set with an equals as I'd interpreted it and this didn't get caught in tests as it was behind a `Rails.env.production?` conditional. https://github.com/alphagov/govuk-puppet/pull/9187 should allow us to remove those conditionals so this can be tested. 

I've tested this out with a government-frontend build: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/9640/console which passes.

And I've also deployed this to integration to check the CSP output matches.

Current government-frontend release (govuk_app_config 1.16.2)

```
Content-Security-Policy-Report-Only: default-src https 'self' *.publishing.service.gov.uk localhost; img-src data: 'self' *.publishing.service.gov.uk localhost www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net assets.digital.cabinet-office.gov.uk; script-src 'self' *.publishing.service.gov.uk localhost www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.signin.service.gov.uk *.ytimg.com www.youtube.com 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk localhost 'unsafe-inline'; font-src data: 'self' *.publishing.service.gov.uk localhost; connect-src 'self' *.publishing.service.gov.uk localhost www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; frame-src www.youtube.com; report-uri https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production
```

After:

```
Content-Security-Policy-Report-Only: default-src https: 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk; img-src 'self' data: *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net assets.digital.cabinet-office.gov.uk; script-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.signin.service.gov.uk *.ytimg.com www.youtube.com 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk 'unsafe-inline'; font-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk data:; connect-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.youtube.com; report-uri https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production
```

Difference:

<img width="1219" alt="Screen Shot 2019-06-03 at 11 49 02" src="https://user-images.githubusercontent.com/282717/58797035-ced49c80-85f6-11e9-9245-6718238e1f2a.png">
