### PR TITLE
Set CSP production configuration via ENV vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Use `GOVUK_CSP_REPORT_ONLY` and `GOVUK_CSP_REPORT_URI` to configure
+  content security policy.
+
 # 1.18.1
 
 * Fix incorrect report_uri= method usage in content security policy

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -71,12 +71,11 @@ module GovukContentSecurityPolicy
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
     policy.frame_src :self, *GOVUK_DOMAINS, "www.youtube.com" # Allow youtube embeds
 
-    # AWS Lambda function that filters out junk reports.
-    policy.report_uri "https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production" if Rails.env.production?
+    policy.report_uri ENV["GOVUK_CSP_REPORT_URI"] if ENV.include?("GOVUK_CSP_REPORT_URI")
   end
 
   def self.configure
-    Rails.application.config.content_security_policy_report_only = true if Rails.env.production?
+    Rails.application.config.content_security_policy_report_only = ENV.include?("GOVUK_CSP_REPORT_ONLY")
 
     Rails.application.config.content_security_policy(&method(:build_policy))
   end

--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -18,5 +18,33 @@ RSpec.describe GovukContentSecurityPolicy do
       expect(GovukContentSecurityPolicy.configure)
         .to be_a(ActionDispatch::ContentSecurityPolicy)
     end
+
+    it 'can have a report_uri set by an ENV var' do
+      ClimateControl.modify(GOVUK_CSP_REPORT_URI: 'https://example.com') do
+        policy = GovukContentSecurityPolicy.configure
+        expect(policy.build).to match('report-uri https://example.com')
+      end
+
+      ClimateControl.modify(GOVUK_CSP_REPORT_URI: nil) do
+        policy = GovukContentSecurityPolicy.configure
+        expect(policy.build).not_to match('report-uri')
+      end
+    end
+
+    it 'can be set to report_only by an ENV var' do
+      Rails.application.config.content_security_policy_report_only = false
+
+      ClimateControl.modify(GOVUK_CSP_REPORT_ONLY: 'yes') do
+        expect { GovukContentSecurityPolicy.configure }
+          .to change { Rails.application.config.content_security_policy_report_only }
+          .to(true)
+      end
+
+      ClimateControl.modify(GOVUK_CSP_REPORT_ONLY: nil) do
+        expect { GovukContentSecurityPolicy.configure }
+          .to change { Rails.application.config.content_security_policy_report_only }
+          .to(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
This uses the 12-factor approach of using environment variables to
determine the configuration of the content security policy instead of
using Rails.env.production?

This has a few advantages:

- We can set different report_uri for different apps (the current one is
  set up for frontend GOV.UK apps)
- These lines of codes are executed in test environments, which caused a
  problem in 86f9a0e
- This breaks the assumption that Rails.env.production means this is
  running in GOV.UK integration/staging/production which is useful as this
  is used for running end-to-end tests and should be available if devs
  wish to try out production optimisations.

Environment variables for these were introduced to Puppet in
https://github.com/alphagov/govuk-puppet/pull/9187 and were released to
production in release_21895