### PR TITLE
Release version 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.19.0
 
 * Use `GOVUK_CSP_REPORT_ONLY` and `GOVUK_CSP_REPORT_URI` to configure
   content security policy.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.18.1"
+  VERSION = "1.19.0"
 end


### PR DESCRIPTION
Use `GOVUK_CSP_REPORT_ONLY` and `GOVUK_CSP_REPORT_URI` environment
variables to configure content security policy.

I've flagged this a minor version as there is not any backwards
compatibility concerns for GOV.UK applications as puppet already has
these environment variables.