### PR TITLE
Fix CSP in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix CSP in development
+
 # 1.19.0
 
 * Use `GOVUK_CSP_REPORT_ONLY` and `GOVUK_CSP_REPORT_URI` to configure

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ logs to `STDOUT` and unstructed logs to `STDERR`.
 ## Content Security Policy generation
 
 For frontend apps, configuration can be added to generate and serve a
-content security policy header. The policy is report only when the Rails
-environment is set to "production", and enforced otherwise.
+content security policy header. The policy is report only when the
+environment variable `GOVUK_CSP_REPORT_ONLY` is set, and enforced otherwise.
 
 To enable this feature, create a file at `config/initializers/csp.rb` in the
 app with the following content:

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -10,7 +10,8 @@ module GovukContentSecurityPolicy
 
   GOVUK_DOMAINS = [
     '*.publishing.service.gov.uk',
-    "*.#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}"
+    "*.#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}",
+    "*.dev.gov.uk"
   ].uniq.freeze
 
   GOOGLE_ANALYTICS_DOMAINS = %w(www.google-analytics.com


### PR DESCRIPTION
Most frontend apps in development can be started with `--live`, which sets the `GOVUK_APP_DOMAIN` to `www.gov.uk` ([government-frontend for example](https://github.com/alphagov/government-frontend/blob/master/startup.sh)).

Should clear up the confusion in https://github.com/alphagov/govuk-developer-docs/pull/1845#discussion_r301455194.
