### PR TITLE
Update error reporting code

### DIFF
--- a/spec/integration/configuring_spec.rb
+++ b/spec/integration/configuring_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Requiring govuk_app_config' do
       require 'govuk_app_config'
 
       expect(Raven.configuration.current_environment).to eql('integration-or-somesuch')
-      expect { Raven.configuration.should_capture.call('foo') }.not_to raise_error
+      expect { Raven.configuration.before_send.call('foo') }.not_to raise_error
       expect { Raven.configuration.transport_failure_callback.call('foo') }.not_to raise_error
     end
   end


### PR DESCRIPTION
This commit:

- Uses the new `before_send` for pre-send stats. Because we now track all error types, the key is renamed.
- Use `config.inspect_exception_causes_for_exclusion` for excluding exceptions
- Remove "errbit" error key, as it's no longer used.

Similar to https://github.com/alphagov/govuk_app_config/pull/70.