### PR TITLE
Fix reporting errors cause an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix regression in error reporting code which caused an error.
+
 # 1.20.0
 
 * Fix CSP in development

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -2,6 +2,7 @@ GovukError.configure do |config|
   config.before_send = Proc.new { |e|
     GovukStatsd.increment("errors_occurred")
     GovukStatsd.increment("error_types.#{e.class.name.demodulize.underscore}")
+    e
   }
 
   config.silence_ready = !Rails.env.production? if defined?(Rails)


### PR DESCRIPTION
The `config.before_send` function has to return the event to send:

https://github.com/getsentry/raven-ruby/blob/master/lib/raven/client.rb#L24-L31