### PR TITLE
Fix incorrect error constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Fix GdsApi::HTTPIntermittentServer errors no longer being filtered from
+  exceptions sent to Sentry.
+
 # 1.20.1
 
 * Fix regression in error reporting code which caused an error.

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -19,7 +19,7 @@ GovukError.configure do |config|
     'ActiveJob::DeserializationError',
     'ActiveRecord::RecordNotFound',
     'CGI::Session::CookieStore::TamperedWithCookie',
-    'GdsApi::HTTPIntermittent',
+    'GdsApi::HTTPIntermittentServerError',
     'GdsApi::TimedOutException',
     'Mongoid::Errors::DocumentNotFound',
     'Sinatra::NotFound',


### PR DESCRIPTION
There is no such constant in gds-api-adapters as
GdsApi::HTTPIntermittent. Instead there are two different constants that
are prefixed with GdsApi::HTTPIntermittent:
GdsApi::HTTPIntermittentClientError and
GdsApi::HTTPIntermittentServerError. Thus errors are now being reported
that would previously been excluded.

Presumably this mistake was made as we were previously just checking the
prefix of the class name in [1].

I decided we should only exclude intermittent server errors as applications
should be informed if they are making a client error (the case where you
would get a HTTPIntermittentClientError would be for too many requests, 429).

[1]: https://github.com/alphagov/govuk_app_config/commit/3c46b628a899717e7aec40273cf920bf7ff1a7c1