### PR TITLE
Release version 1.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.20.2
 
 * Fix GdsApi::HTTPIntermittentServer errors no longer being filtered from
   exceptions sent to Sentry.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "1.20.1"
+  VERSION = "1.20.2"
 end


### PR DESCRIPTION
 * Fix GdsApi::HTTPIntermittentServer errors no longer being filtered from
   exceptions sent to Sentry.