### PR TITLE
GovukLogging is required before Railtie

### DIFF
--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -8,7 +8,7 @@ require "govuk_app_config/govuk_unicorn"
 require "govuk_app_config/configure"
 
 if defined?(Rails)
-  require "govuk_app_config/railtie"
   require "govuk_app_config/govuk_logging"
   require "govuk_app_config/govuk_content_security_policy"
+  require "govuk_app_config/railtie"
 end


### PR DESCRIPTION
This ordering was causing a problem for govuk_publishing_components which prevented assets to be pre-compiled:

```
govuk_publishing_components git:(master) RAILS_ENV=production GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=https://www.gov.uk rake assets:precompile
rake aborted!
NameError: uninitialized constant GovukAppConfig::Railtie::GovukLogging
/Users/kevindew/govuk/govuk_publishing_components/spec/dummy/config/initializers/content_security_policy.rb:1:in `<top (required)>'
/Users/kevindew/govuk/govuk_publishing_components/spec/dummy/config/environment.rb:5:in `<top (required)>'
/Users/kevindew/govuk/govuk_publishing_components/Rakefile:18:in `block (2 levels) in <top (required)>'
```

This was due to the Railtie file executing it's initializer before the remaining files had been required. This can be resolved with the Railtie being required last.