### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.1
+
+* Reorder requires to resolve: "NameError: uninitialized constant
+  GovukAppConfig::Railtie::GovukLogging"
+
 # 2.0.0
 
 * Remove support for AWS X-Ray.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
* Reorder requires to resolve: "NameError: uninitialized constant
  GovukAppConfig::Railtie::GovukLogging"