### PR TITLE
Allow Rails 6 apps to run via GOV.UK Docker

### DIFF
--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -3,5 +3,9 @@ module GovukAppConfig
     config.before_initialize do
       GovukLogging.configure if Rails.env.production?
     end
+
+    if Rails.env.development? && config.respond_to?(:hosts)
+      config.hosts << "#{File.basename(Rails.root)}.dev.gov.uk"
+    end
   end
 end


### PR DESCRIPTION
- Rails 6 uses a [safelist of hosts in development, including localhost](https://www.fngtps.com/2019/rails6-blocked-host/).
- This doesn't work by default with GOV.UK Docker as we use
  `app-name.dev.gov.uk` hosts. It gives errors like
  https://github.com/alphagov/govuk-docker/issues/ 174, further explored
  in https://github.com/alphagov/support/pull/ 687.
- To fix it, we need to add `config.hosts << "app-name.dev.gov.uk"` to
  every app that uses GOV.UK Docker. We can _only_ do this when they run
  Rails 6, because `config.hosts` only exists on Rails 6.
- This would be slow and tedious to add to every app as part of the
  upgrade (there are a lot of them!) so this is a shortcut that applies
  to every app that uses this gem (that should be most of them).

Co-authored-by: Issy Long <isabell.long@digital.cabinet-office.gov.uk>
Co-authored-by: Thomas Leese <thomas.leese@digital.cabinet-office.gov.uk>