### PR TITLE
Added script-src for Nuance/HMRC Webchat provider

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -41,6 +41,8 @@ module GovukContentSecurityPolicy
                       "*.ytimg.com",
                       "www.youtube.com",
                       "www.youtube-nocookie.com",
+                      # Allow JSONP call to Nuance - HMRC web chat provider
+                      "hmrc-uk.digital.nuance.com",
                       # Allow all inline scripts until we can conclusively
                       # document all the inline scripts we use,
                       # and there's a better way to filter out junk reports


### PR DESCRIPTION
Have added an entry for the new HMRC webchat provider URL, sitting on the Nuance domain. 

This is to facilitate calling an availability API endpoint on the third-parties domain and not throwing CORS or CSP issues when the ajax request originates on gov.uk contact pages.