### PR TITLE
Include information re. icinga in message section of healthcheck doc

### DIFF
--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -22,7 +22,7 @@ class CustomCheck
 
   # Optional
   def message
-    "This is an optional custom message"
+    "This is an optional custom message that will show up in the alert in Icinga"
   end
 
   # Optional


### PR DESCRIPTION
I recently did some work on a healthcheck endpoint and noticed that some apps were using the details method in their healthchecks to provide information that should be showing up in icinga. It took me quite a while to work out that it's the message method rather than details that icinga actually shows. This updates the docs to make it clear that the message method provides a string that can be seen in icinga.