### PR TITLE
Exclude `Mime::Type::InvalidMimeType` exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Exclude `Mime::Type::InvalidMimeType` exception (https://github.com/alphagov/govuk_app_config/pull/137)
+
 # 2.0.3
 
 * Add hmrc-uk.digital.nuance.com (Nuance/HMRC Webchat provider) and gov.klick2contact.com (HMPO web chat provider) to connect-src CSP list (https://github.com/alphagov/govuk_app_config/pull/133)

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -21,6 +21,7 @@ GovukError.configure do |config|
     'CGI::Session::CookieStore::TamperedWithCookie',
     'GdsApi::HTTPIntermittentServerError',
     'GdsApi::TimedOutException',
+    'Mime::Type::InvalidMimeType',
     'Mongoid::Errors::DocumentNotFound',
     'Sinatra::NotFound',
   ]


### PR DESCRIPTION
After upgrading `frontend` to rails 6, we started seeing this error:
`Mime::Type::InvalidMimeType "charset=utf-8" is not a valid MIME type`
Example here:
https://sentry.io/organizations/govuk/issues/1549200925/?end=2020-03-06T12%3A00%3A23&environment=staging&project=202225&query=is%3Aunresolved+url%3Ahttps%3A%2F%2Fwww-origin.staging.govuk.digital%2Freport-an-unregistered-trader-or-business&start=2020-03-05T16%3A07%3A23&utc=true

This is because, even though these errors are rescued by ActionDispatch,
they still reach Sentry. Here's the explanation from Sentry's docs:
> Rails catches exceptions in the ActionDispatch::ShowExceptions or
> ActionDispatch::DebugExceptions middlewares, depending on the
> environment. When rails_report_rescued_exceptions is true (it is by
> default), Raven will report exceptions even when they are rescued by
> these middlewares.

So, in order to stop this behaviour, we set this option to be false for
`frontend` in this PR: https://github.com/alphagov/frontend/issues/2264

We also want to explicitly add `Mime::Type::InvalidMimeType` to the list
of excluded exceptions, hence this PR.

Trello card: https://trello.com/c/Ik7ulDXQ/1768-3-upgrade-frontend-to-rails-6