### PR TITLE
Do not report exceptions rescued by rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Stop exceptions rescued by rails from appearing in Sentry (https://github.com/alphagov/govuk_app_config/pull/138)
+
 # 2.0.3
 
 * Add hmrc-uk.digital.nuance.com (Nuance/HMRC Webchat provider) and gov.klick2contact.com (HMPO web chat provider) to connect-src CSP list (https://github.com/alphagov/govuk_app_config/pull/133)

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -33,4 +33,8 @@ GovukError.configure do |config|
   config.transport_failure_callback = Proc.new {
     GovukStatsd.increment("error_reports_failed")
   }
+
+  # This stops exceptions rescued by rails from appearing in Sentry.
+  # See https://www.rubydoc.info/gems/sentry-raven/1.2.2/Raven%2FConfiguration:rails_report_rescued_exceptions
+  config.rails_report_rescued_exceptions = false
 end

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -8,16 +8,9 @@ GovukError.configure do |config|
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
   config.excluded_exceptions = [
-    'AbstractController::ActionNotFound',
-    'ActionController::BadRequest',
-    'ActionController::InvalidAuthenticityToken',
-    'ActionController::ParameterMissing',
-    'ActionController::RoutingError',
     'ActionController::UnknownAction',
-    'ActionController::UnknownHttpMethod',
     'ActionDispatch::RemoteIp::IpSpoofAttackError',
     'ActiveJob::DeserializationError',
-    'ActiveRecord::RecordNotFound',
     'CGI::Session::CookieStore::TamperedWithCookie',
     'GdsApi::HTTPIntermittentServerError',
     'GdsApi::TimedOutException',


### PR DESCRIPTION
TL;DR: This stops exceptions rescued by rails from appearing in Sentry.

After upgrading `frontend` to rails 6, we started seeing this error:
`Mime::Type::InvalidMimeType "charset=utf-8" is not a valid MIME type`
Example here:
https://www.sentry.io/organizations/govuk/issues/1549200925/?end=2020-03-06T12%3A00%3A23&environment=staging&project=202225&query=is%3Aunresolved+url%3Ahttps%3A%2F%2Fwww-origin.staging.govuk.digital%2Freport-an-unregistered-trader-or-business&start=2020-03-05T16%3A07%3A23&utc=true

This is because, even though these errors are rescued by ActionDispatch,
they still reach Sentry. Here's the explanation from Sentry's docs:

> Rails catches exceptions in the ActionDispatch::ShowExceptions or
> ActionDispatch::DebugExceptions middlewares, depending on the
> environment. When rails_report_rescued_exceptions is true (it is by
> default), Raven will report exceptions even when they are rescued by
> these middlewares.

So, in order to stop this behaviour, we initially took a double
approach:
- set that option to be false for `frontend` in
[this PR](https://github.com/alphagov/frontend/pull/2264) to stop all
exceptions rescued by rails (not only `Mime::Type::InvalidMimeType`)
from appearing in Sentry for `frontend`
- explicitly added `Mime::Type::InvalidMimeType` to the list of
excluded exceptions in
[this PR](https://github.com/alphagov/govuk_app_config/pull/137) to stop
`Mime::Type::InvalidMimeType` from appearing in Sentry for all apps that
depend on `govuk_app_config`

Setting `rails_report_rescued_exceptions` to `false` here is better
because it will apply this config to all apps that depend on
`govuk_app_config`, making the two PRs above redundant and saving us
from making this change in every app.

Setting `config.rails_report_rescued_exceptions` to `false` makes having
these exceptions in `config.excluded_exceptions` redundant.

All the exceptions present in `config.action_dispatch.rescue_responses`
can be removed from `config.excluded_exceptions`.

See
https://guides.rubyonrails.org/configuring.html#configuring-action-dispatch
for the list of exceptions in `config.action_dispatch.rescue_responses`.

Trello card: https://trello.com/c/Ik7ulDXQ/1768-3-upgrade-frontend-to-rails-6