### PR TITLE
Revert rails_report_rescued_exceptions = false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Revert using Sentry option of rails_report_rescued_exceptions (https://github.com/alphagov/govuk_app_config/pull/140)
+
 # 2.1.0
 
 * Stop exceptions rescued by rails from appearing in Sentry (https://github.com/alphagov/govuk_app_config/pull/138)

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -8,21 +8,29 @@ GovukError.configure do |config|
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
   config.excluded_exceptions = [
-    'AbstractController::ActionNotFound',
-    'ActionController::BadRequest',
-    'ActionController::InvalidAuthenticityToken',
-    'ActionController::ParameterMissing',
-    'ActionController::RoutingError',
-    'ActionController::UnknownAction',
-    'ActionController::UnknownHttpMethod',
-    'ActionDispatch::RemoteIp::IpSpoofAttackError',
-    'ActiveJob::DeserializationError',
-    'ActiveRecord::RecordNotFound',
-    'CGI::Session::CookieStore::TamperedWithCookie',
-    'GdsApi::HTTPIntermittentServerError',
-    'GdsApi::TimedOutException',
-    'Mongoid::Errors::DocumentNotFound',
-    'Sinatra::NotFound',
+    # default Rails rescue responses
+    "ActionController::RoutingError",
+    "AbstractController::ActionNotFound",
+    "ActionController::MethodNotAllowed",
+    "ActionController::UnknownHttpMethod",
+    "ActionController::NotImplemented",
+    "ActionController::UnknownFormat",
+    "Mime::Type::InvalidMimeType",
+    "ActionController::MissingExactTemplate",
+    "ActionController::InvalidAuthenticityToken",
+    "ActionController::InvalidCrossOriginRequest",
+    "ActionDispatch::Http::Parameters::ParseError",
+    "ActionController::BadRequest",
+    "ActionController::ParameterMissing",
+    "Rack::QueryParser::ParameterTypeError",
+    "Rack::QueryParser::InvalidParameterError",
+    # additional items
+    "ActiveJob::DeserializationError",
+    "CGI::Session::CookieStore::TamperedWithCookie",
+    "GdsApi::HTTPIntermittentServerError",
+    "GdsApi::TimedOutException",
+    "Mongoid::Errors::DocumentNotFound",
+    "Sinatra::NotFound",
   ]
 
   # This will exclude exceptions that are triggered by one of the ignored

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -8,9 +8,16 @@ GovukError.configure do |config|
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
   config.excluded_exceptions = [
+    'AbstractController::ActionNotFound',
+    'ActionController::BadRequest',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionController::ParameterMissing',
+    'ActionController::RoutingError',
     'ActionController::UnknownAction',
+    'ActionController::UnknownHttpMethod',
     'ActionDispatch::RemoteIp::IpSpoofAttackError',
     'ActiveJob::DeserializationError',
+    'ActiveRecord::RecordNotFound',
     'CGI::Session::CookieStore::TamperedWithCookie',
     'GdsApi::HTTPIntermittentServerError',
     'GdsApi::TimedOutException',
@@ -26,8 +33,4 @@ GovukError.configure do |config|
   config.transport_failure_callback = Proc.new {
     GovukStatsd.increment("error_reports_failed")
   }
-
-  # This stops exceptions rescued by rails from appearing in Sentry.
-  # See https://www.rubydoc.info/gems/sentry-raven/1.2.2/Raven%2FConfiguration:rails_report_rescued_exceptions
-  config.rails_report_rescued_exceptions = false
 end


### PR DESCRIPTION
This reverts https://github.com/alphagov/govuk_app_config/pull/138

It turns out that this setting was more aggressive than we anticipated
and was actually preventing the reporting of any exception that Rails
handled. We had thought that this only prevented the reporting of
exceptions specially configured as Rails rescue responses.

It transpires that this stops the reporting of any exceptions that are
handled by ActionDispatch::ShowExceptions [1] which is effectively all
Rails exceptions as per raven-ruby [2].

[1]: https://github.com/rails/rails/blob/38ec8db3f7d3c79936cdaa0a136b26ee1c977f7d/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
[2]: https://github.com/getsentry/raven-ruby/blob/d9d41784c3b5888295bf4b013416f132045b22d4/lib/raven/integrations/rails.rb#L51-L52