### PR TITLE
Exclude ActiveRecord rescue responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # 2.1.1
 
-* revert using sentry option of rails_report_rescued_exceptions (https://github.com/alphagov/govuk_app_config/pull/140)
+* Revert using sentry option of rails_report_rescued_exceptions (https://github.com/alphagov/govuk_app_config/pull/140)
 
 # 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# Unreleased
+
+* Add missing ActiveRecord rescue_responses (https://github.com/alphagov/govuk_app_config/pull/142)
+
 # 2.1.1
 
-* Revert using Sentry option of rails_report_rescued_exceptions (https://github.com/alphagov/govuk_app_config/pull/140)
+* revert using sentry option of rails_report_rescued_exceptions (https://github.com/alphagov/govuk_app_config/pull/140)
 
 # 2.1.0
 

--- a/lib/govuk_app_config/configure.rb
+++ b/lib/govuk_app_config/configure.rb
@@ -8,7 +8,7 @@ GovukError.configure do |config|
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
   config.excluded_exceptions = [
-    # default Rails rescue responses
+    # Default ActionDispatch rescue responses
     "ActionController::RoutingError",
     "AbstractController::ActionNotFound",
     "ActionController::MethodNotAllowed",
@@ -24,7 +24,12 @@ GovukError.configure do |config|
     "ActionController::ParameterMissing",
     "Rack::QueryParser::ParameterTypeError",
     "Rack::QueryParser::InvalidParameterError",
-    # additional items
+    # Default ActiveRecord rescue responses
+    "ActiveRecord::RecordNotFound",
+    "ActiveRecord::StaleObjectError",
+    "ActiveRecord::RecordInvalid",
+    "ActiveRecord::RecordNotSaved",
+    # Additional items
     "ActiveJob::DeserializationError",
     "CGI::Session::CookieStore::TamperedWithCookie",
     "GdsApi::HTTPIntermittentServerError",


### PR DESCRIPTION
In updating the default Rails ones I failed to realise that some were
configured in ActionDispatch [1] and others were in ActiveRecord [2] so
the last iteration of this missed all of these.

[1]: https://github.com/rails/rails/blob/eed9f15ba87d4d4c9be48119e55e8ff17102c4a7/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L8-L24
[2]: https://github.com/rails/rails/blob/eed9f15ba87d4d4c9be48119e55e8ff17102c4a7/activerecord/lib/active_record/railtie.rb#L22-L27