### PR TITLE
Bump to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.1.2
 
 * Add missing ActiveRecord rescue_responses (https://github.com/alphagov/govuk_app_config/pull/142)
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
Add missing ActiveRecord rescue_responses (https://github.com/alphagov/govuk_app_config/pull/142)