### PR TITLE
Fix spelling of `supressed` => `suppressed`

### DIFF
--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -50,7 +50,7 @@ module GovukLogging
         "#{String === msg ? msg : msg.inspect}\n"
       }
     )
-    Rails.application.config.logstasher.supress_app_log = true
+    Rails.application.config.logstasher.suppress_app_log = true
 
     if defined?(GdsApi::Base)
       GdsApi::Base.default_options ||= {}


### PR DESCRIPTION
This was fixed in logstasher here: https://github.com/shadabahmed/logstasher/commit/bc9e6cfed51a9aea3f27610ee0bcf1d90db5da9b

They've maintained backwards compatibility but it is better if we use the correct parameter, just in
case configuration has shifted. It will also make it easier to look up the correct documentation.

Arises from https://trello.com/c/fX8U5tly/1911-5-fix-whitehall-stacktraces-in-kibana