### PR TITLE
Monkey patch log_error - format errors on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+* Monkey patch `ActionDispatch::DebugExceptions#log_error` so it logs errors on a single line (https://github.com/alphagov/govuk_app_config/pull/147)
+
 # 2.1.2
 
 * Add missing ActiveRecord rescue_responses (https://github.com/alphagov/govuk_app_config/pull/142)

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "climate_control"
+  spec.add_development_dependency "rack-test", "~> 0.6.3"
   spec.add_development_dependency "rails", "~> 6"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9.0"

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -1,5 +1,6 @@
 require 'logstasher'
 require 'action_controller'
+require_relative 'rails_ext/action_dispatch/debug_exceptions'
 
 module GovukLogging
   def self.configure
@@ -61,5 +62,7 @@ module GovukLogging
       GdsApi::Base.default_options[:logger] =
         Rails.application.config.logstasher.logger
     end
+
+    RailsExt::ActionDispatch.monkey_patch_log_error if RailsExt::ActionDispatch.should_monkey_patch_log_error
   end
 end

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -63,6 +63,6 @@ module GovukLogging
         Rails.application.config.logstasher.logger
     end
 
-    RailsExt::ActionDispatch.monkey_patch_log_error if RailsExt::ActionDispatch.should_monkey_patch_log_error
+    RailsExt::ActionDispatch.monkey_patch_log_error if RailsExt::ActionDispatch.should_monkey_patch_log_error?
   end
 end

--- a/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
+++ b/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
@@ -3,8 +3,8 @@ require "action_dispatch/middleware/debug_exceptions"
 module GovukLogging
   module RailsExt
     module ActionDispatch
-      def self.should_monkey_patch_log_error
-        empty_instance = ::ActionDispatch::DebugExceptions.new nil
+      def self.should_monkey_patch_log_error?(clazz = ::ActionDispatch::DebugExceptions)
+        empty_instance = clazz.new nil
         target_method = empty_instance.method :log_error
 
         expected_parameters = [%i[req request], %i[req wrapper]]
@@ -26,8 +26,8 @@ module GovukLogging
         false
       end
 
-      def self.monkey_patch_log_error
-        ::ActionDispatch::DebugExceptions.class_eval do
+      def self.monkey_patch_log_error(clazz = ::ActionDispatch::DebugExceptions)
+        clazz.class_eval do
           private
 
           def log_error(request, wrapper)

--- a/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
+++ b/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
@@ -1,0 +1,53 @@
+require "action_dispatch/middleware/debug_exceptions"
+
+module GovukLogging
+  module RailsExt
+    module ActionDispatch
+      def self.should_monkey_patch_log_error
+        empty_instance = ::ActionDispatch::DebugExceptions.new nil
+        target_method = empty_instance.method :log_error
+
+        expected_parameters = [%i[req request], %i[req wrapper]]
+        actual_parameters = target_method.parameters
+
+        should_monkey_patch = actual_parameters == expected_parameters
+
+        unless should_monkey_patch
+          Rails.logger.warn "Refused to monkey patch ::ActionDispatch::DebugExceptions#log_error - " +
+            "signatures do not match. " +
+            "Expected #{expected_parameters}, but got #{actual_parameters}"
+        end
+
+        should_monkey_patch
+
+      rescue StandardError => ex
+        Rails.logger.warn "Failed to detect whether to monkey patch " +
+          "::ActionDispatch::DebugExceptions#log_error - #{ex.inspect}"
+        false
+      end
+
+      def self.monkey_patch_log_error
+        ::ActionDispatch::DebugExceptions.class_eval do
+          private
+
+          def log_error(request, wrapper)
+            logger = logger(request)
+
+            return unless logger
+
+            exception = wrapper.exception
+
+            trace = wrapper.application_trace
+            trace = wrapper.framework_trace if trace.empty?
+
+            logger.fatal({
+              exception_class: exception.class.to_s,
+              exception_message: exception.message,
+              stacktrace: trace,
+            }.to_json)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -5,13 +5,21 @@ require 'govuk_app_config/govuk_logging'
 RSpec.describe GovukLogging do
   class DummyLoggingRailsApp < Rails::Application; end
 
+  old_stderr = nil
+
   let(:fake_stdout) { StringIO.new }
   let(:info_log_level) { 1 }
 
   before do
+    old_stderr = $stderr
+    $stderr = StringIO.new
     allow($stdout).to receive(:clone).and_return(fake_stdout)
     allow($stdout).to receive(:reopen)
     Rails.logger = Logger.new(fake_stdout, level: info_log_level)
+  end
+
+  after do
+    $stderr = old_stderr
   end
 
   describe '.configure' do
@@ -35,6 +43,15 @@ RSpec.describe GovukLogging do
       fake_stdout.rewind
 
       expect(fake_stdout.read).to match(/test log entry/)
+    end
+
+    it 'can write to default rails logger' do
+      GovukLogging.configure
+      logger = Rails.logger
+      logger.info('test default log entry')
+      $stderr.rewind
+
+      expect($stderr.read).to match(/test default log entry/)
     end
   end
 end

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -70,7 +70,15 @@ RSpec.describe GovukLogging do
         GovukLogging.configure
         get '/error'
         $stderr.rewind
-        expect($stderr.read).to match(/some error/)
+        lines = $stderr.read.split("\n")
+        expect(lines).to include(/default exception/)
+        error_log_line = lines.find{|log| log.match?(/default exception/) }
+        expect(error_log_line).not_to be_empty
+        expect(error_log_line).to start_with("{")
+        expect(error_log_line).to end_with("}")
+        expect(error_log_line).to match(/"exception_class"\s*:\s*"Exception"/)
+        expect(error_log_line).to match(/"exception_message"\s*:\s*"default exception"/)
+        expect(error_log_line).to match(/"stacktrace"\s*:\s*\["/)
       end
     end
   end

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -74,11 +74,13 @@ RSpec.describe GovukLogging do
         expect(lines).to include(/default exception/)
         error_log_line = lines.find{|log| log.match?(/default exception/) }
         expect(error_log_line).not_to be_empty
-        expect(error_log_line).to start_with("{")
-        expect(error_log_line).to end_with("}")
-        expect(error_log_line).to match(/"exception_class"\s*:\s*"Exception"/)
-        expect(error_log_line).to match(/"exception_message"\s*:\s*"default exception"/)
-        expect(error_log_line).to match(/"stacktrace"\s*:\s*\["/)
+        error_log_json = JSON.parse(error_log_line)
+        expect(error_log_json).to match(hash_including(
+          "exception_class" => "Exception",
+          "exception_message" => "default exception",
+        ))
+        expect(error_log_json).to have_key("stacktrace")
+        expect(error_log_json["stacktrace"]).to be_a(Array)
       end
     end
   end

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -53,5 +53,18 @@ RSpec.describe GovukLogging do
 
       expect($stderr.read).to match(/test default log entry/)
     end
+
+    it 'logs errors in middleware' do
+      allow(Rails.application).to receive(:call).and_raise(Exception.new("some error"))
+
+      GovukLogging.configure
+      middleware = ::ActionDispatch::DebugExceptions.new(Rails.application)
+      begin
+        middleware.call({})
+      rescue Exception
+        $stderr.rewind
+        expect($stderr.read).to match(/some error/)
+      end
+    end
   end
 end

--- a/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'rails'
+require 'govuk_app_config/rails_ext/action_dispatch/debug_exceptions'
+
+RSpec.describe ::GovukLogging::RailsExt::ActionDispatch do
+  describe "#should_monkey_patch_log_error?" do
+    before do
+      Rails.logger = double(:rails_logger)
+      allow(Rails.logger).to receive(:warn)
+    end
+
+    it "should not monkey patch classes which do not have log_error" do
+      class NoMethodTestClass; end
+      expect(described_class.should_monkey_patch_log_error? NoMethodTestClass).to be(false)
+    end
+
+    it "should not monkey patch classes which have log_error with different params" do
+      class WrongParametersTestClass
+        private
+        def log_error(_different, _parameters); end
+      end
+      expect(described_class.should_monkey_patch_log_error? WrongParametersTestClass).to be(false)
+    end
+
+    it "should monkey patch classes which have log_error with the same params" do
+      class RightParametersTestClass
+        private
+        def log_error(request, wrapper); end
+      end
+      expect(described_class.should_monkey_patch_log_error? RightParametersTestClass).to be(false)
+    end
+  end
+
+  describe "#monkey_patch_log_error" do
+    it "should replace the private log_error method" do
+      class FakeDebugExceptions
+        def log_error(request, wrapper); end
+      end
+      instance = FakeDebugExceptions.new
+
+      expect {
+        described_class.monkey_patch_log_error(FakeDebugExceptions)
+      }.to change {
+        instance.method(:log_error)
+      }
+    end
+  end
+end


### PR DESCRIPTION
It's annoying having Rails log errors across multiple lines, as it makes
indexing them in logstash very difficult.

:warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey:
This PR involves monkey patching a small bit of rails
:warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey: :warning: :monkey:

The ActionDispatch::DebugExceptions middleware is the culprit that's logging
errors across multiple lines. Since it would be a bit of a nuisance to have to
replace this middleware entirely (it does other things too - like rendering
error pages in dev), it seems more "surgical" just to replace the `log_error`
method with one that does what we want.

We've tried to be very careful to check that doing this doesn't break anything,
and we think that the test coverage we're adding should catch any regressions.

At the end of the day, if Matz had not wanted us to do bad things, he would not
have given us free will.

https://trello.com/c/fX8U5tly/1911-5-show-stacktraces-as-one-log-entry-in-kibana-%F0%9F%8D%90