### PR TITLE
Add two missing Google domains to Content Security Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+  
+* Add www.googletagmanager.com and www.gstatic.com to Content Security Policy (https://github.com/alphagov/govuk_app_config/pull/153)
+
 # 2.2.1
 
 * Fix linting issues (https://github.com/alphagov/govuk_app_config/pull/149)

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -20,6 +20,8 @@ module GovukContentSecurityPolicy
                                 stats.g.doubleclick.net
                                 www.googletagmanager.com].freeze
 
+  GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
+
   def self.build_policy(policy)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
     policy.default_src :https, :self, *GOVUK_DOMAINS
@@ -36,6 +38,7 @@ module GovukContentSecurityPolicy
     policy.script_src :self,
                       *GOVUK_DOMAINS,
                       *GOOGLE_ANALYTICS_DOMAINS,
+                      *GOOGLE_STATIC_DOMAINS,
                       # Allow JSONP call to Verify to check whether the user is logged in
                       "www.signin.service.gov.uk",
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
@@ -52,6 +55,7 @@ module GovukContentSecurityPolicy
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
     policy.style_src :self,
                      *GOVUK_DOMAINS,
+                     *GOOGLE_STATIC_DOMAINS,
                      # We use the `style=""` attribute on some HTML elements
                      :unsafe_inline
 

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -17,7 +17,8 @@ module GovukContentSecurityPolicy
 
   GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
                                 ssl.google-analytics.com
-                                stats.g.doubleclick.net].freeze
+                                stats.g.doubleclick.net
+                                www.googletagmanager.com].freeze
 
   def self.build_policy(policy)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src


### PR DESCRIPTION
We are making requests to www.googletagmanager.com in govuk_publishing_components [1], and including JavaScript and CSS from www.gstatic.com in content-data-admin [2].  All were being blocked by the Content Security Policy, therefore adding these domains to the policy.

1: https://github.com/alphagov/govuk_publishing_components/blob/21e5808e03e7c97721cefe533b315753db7c5403/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb#L16
2: https://github.com/alphagov/content-data-admin/blob/2bbf6cd4bbae29ec02107f4341d526f7707be6d6/app/views/layouts/application.html.erb#L2