### PR TITLE
WIP: Provide custom fingerprinting algorithm for Sentry

### DIFF
--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -7,6 +7,11 @@ GovukError.configure do |config|
 
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
+  config.before_send = lambda { |event, hint|
+    event.fingerprint = GovukError::CustomFingerprint.sample(event)
+    event
+  }
+
   config.excluded_exceptions = [
     # Default ActionDispatch rescue responses
     "ActionController::RoutingError",

--- a/lib/govuk_app_config/govuk_error/custom_fingerprint.rb
+++ b/lib/govuk_app_config/govuk_error/custom_fingerprint.rb
@@ -1,0 +1,10 @@
+module GovukError
+  class CustomFingerprint
+    def self.sample(event)
+      # TODO - it's not clear if this is possible, given that Ruby SDK fingerprinting
+      # has no documentation: https://docs.sentry.io/platforms/ruby/data-management/event-grouping/sdk-fingerprinting/
+      # The implication is that it's not supported yet.
+      ["fingerprint"]
+    end
+  end
+end

--- a/spec/govuk_error/custom_fingerprint_spec.rb
+++ b/spec/govuk_error/custom_fingerprint_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "govuk_app_config/govuk_error/custom_fingerprint"
+
+RSpec.describe GovukError::CustomFingerprint do
+  describe ".sample" do
+    # See https://www.rubydoc.info/gems/sentry-raven/Raven/Event
+    it "takes a Raven::Event as a parameter and returns an array" do
+      event = double("Raven::Event")
+      fingerprint = GovukError::CustomFingerprint.sample(event)
+      expect(fingerprint).to be_an_instance_of(Array)
+    end
+
+    # As you can see below, we'd be adding complexity to govuk_app_config
+    # by deviating from the defaults.
+    # An alternative is to stick with the default fingerprinting metric,
+    # but use server side fingerprinting, but this has to be configured in
+    # the Sentry UI itself.
+    # https://docs.sentry.io/platforms/ruby/data-management/event-grouping/server-side-fingerprinting/
+
+    it "matches by stack trace in the first instance" do
+      # TODO
+    end
+
+    it "uses a stack trace that only includes 'application frames'" do
+      # TODO
+    end
+
+    it "matches by error name and transaction if stack trace is unavailable (either missing to begin with, or after being stripped of 'framework frames'" do
+      # TODO
+    end
+  end
+end


### PR DESCRIPTION
Process we intend to code up:

1. Reduce stack trace to "application traces" only
2. If no stack trace exists, return the error name instead
3. With support for exception chains. (We then need to think
   about whether it makes sense to reorder them such that the
   originating exception is reported first).
4. Think about where transactions fit into this - they look
   like they were taken into account in the audit.
   https://github.com/getsentry/sentry-ruby/blob/fbbc7a51ed10684d0e8b7bd9d2a1b65a7351c9ef/sentry-ruby/lib/sentry/event.rb#L24

Justification for 1):
- Stack traces that contain "framework traces" are highly
  sensitive to changes in Ruby version, dependencies etc,  and
  thus we often have multiple errors reported in Sentry that
  should really be grouped as one.
- However, we don't want to use Rails::BacktraceCleaner in the
  `backtrace_cleanup_callback` because it's lossy - it removes
  the framework traces altogether, prior to it even getting into
  Sentry, so we lose valuable diagnostic information. We only
  want to remove framework traces for the purposes of
  fingerprinting (grouping); we should still be able to dig into
  the original stack trace when we need to.

Trello: https://trello.com/c/NZNjFHWO/2162-5-improve-sentrys-grouping-of-exceptions