### PR TITLE
Also ignore subclasses of `data_sync_excluded_exceptions`

### DIFF
--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -25,7 +25,7 @@ module GovukError
     def ignore_excluded_exceptions_in_data_sync
       lambda { |error_or_event|
         data_sync_ignored_error = data_sync_excluded_exceptions.any? do |exception_to_ignore|
-          exception_to_ignore = Object.const_get(exception_to_ignore)
+          exception_to_ignore = Object.const_get(exception_to_ignore) unless exception_to_ignore.is_a?(Module)
           exception_chain = Raven::Utils::ExceptionCauseChain.exception_to_array(error_or_event)
           exception_chain.any? { |exception| exception.is_a?(exception_to_ignore) }
         rescue NameError

--- a/spec/govuk_error/configuration_spec.rb
+++ b/spec/govuk_error/configuration_spec.rb
@@ -27,8 +27,14 @@ RSpec.describe GovukError::Configuration do
         expect(configuration.should_capture.call(StandardError.new)).to eq(true)
       end
 
-      it "should ignore errors that have been added to data_sync_excluded_exceptions" do
+      it "should ignore errors that have been added as a string to data_sync_excluded_exceptions" do
         configuration.data_sync_excluded_exceptions << "StandardError"
+
+        expect(configuration.should_capture.call(StandardError.new)).to eq(false)
+      end
+
+      it "should ignore errors that have been added as a class to data_sync_excluded_exceptions" do
+        configuration.data_sync_excluded_exceptions << StandardError
 
         expect(configuration.should_capture.call(StandardError.new)).to eq(false)
       end


### PR DESCRIPTION
We're seeing PG:UndefinedTable errors in Sentry, which we'd like
to ignore during the data sync. By default we're ignoring PG::Error
exceptions already, but this is a specific sub class of PG::Error
(and there are many more we envisage wanting to ignore). We
could list all of these subclasses in the
`data_sync_excluded_exceptions` array, but what we'd rather do
is describe the parent class and have any of its children
exceptions ignored.

`PG::Error === PG::UndefinedTable.new` is true, whereas
`"PG::Error" === PG::UndefinedTable.new.class` is false.
This commit makes the default `should_capture` behaviour dig
deeper into the exception, checking that the exception type
is classed as any one of the errors we've chosen to ignore.

From now on, any exceptions that are a subclass of `PG::Error`
will be ignored during the data sync.

https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig