### PR TITLE
Fix govuk_app_config in Ruby 2.7 environments by explicitly requiring the 'delegate' library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.2
+
+* Fix govuk_app_config in Ruby 2.7 environments by explicitly requiring the 'delegate' library (https://github.com/alphagov/govuk_app_config/pull/167)
+
 # 2.5.1
 
 * Increase scope of `data_sync_excluded_exceptions` so that it includes subclasses (https://github.com/alphagov/govuk_app_config/pull/165)

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "govuk_app_config/govuk_error/govuk_data_sync"
 
 module GovukError

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.5.1".freeze
+  VERSION = "2.5.2".freeze
 end


### PR DESCRIPTION
[Explanation](https://stackoverflow.com/questions/60459709/where-is-simpledelegator-in-ruby-2-7).
TLDR:

> The Delegator and SimpleDelegator classes aren't core classes
> like Array or Mutex. They're part of the delegate standard
> library which needs to be loaded first: require 'delegate'.
> It happened to work in older Ruby versions as they came with an
> older RubyGems version by default. RubyGems is automatically
> loaded since Ruby 1.9 and until 3.1.0 that meant delegate was
> loaded indirectly. Updating RubyGems or running ruby with
> --disable=gems should cause the exact same issue with Ruby <=
> 2.6 too. irb also loads several standard libraries: delegate
> but also timeout and many more.

This is causing the [bouncer build to error](https://github.com/alphagov/bouncer/pull/273).