### PR TITLE
Ignore errors that occur in temporary environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6.0
+
+* Ignore errors that occur in temporary environments (adds `active_sentry_environments` config) (https://github.com/alphagov/govuk_app_config/pull/168)
+
 # 2.5.2
 
 * Fix govuk_app_config in Ruby 2.7 environments by explicitly requiring the 'delegate' library (https://github.com/alphagov/govuk_app_config/pull/167)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you include `govuk_app_config` in your `Gemfile`, Rails' autoloading mechanis
 Your app will have to have the following environment variables set:
 
 - `SENTRY_DSN` - the [Data Source Name (DSN)][dsn] for Sentry
-- `SENTRY_CURRENT_ENV` - production, staging or integration
+- `SENTRY_CURRENT_ENV` - e.g. "production". Make sure it is [configured to be active](#active-sentry-environments).
 - `GOVUK_STATSD_PREFIX` - a Statsd prefix like `govuk.apps.application-name.hostname`
 
 [dsn]: https://docs.sentry.io/quickstart/#about-the-dsn
@@ -77,6 +77,18 @@ GovukError.notify(
   level: "debug", # debug, info, warning, error, fatal
   tags: { key: "value" } # Tags to index with this event. Must be a mapping of strings.
 )
+```
+
+### Active Sentry environments
+
+GovukError will only send errors to Sentry if your `SENTRY_CURRENT_ENV` matches one of the 'active environments' in the [default configuration](https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_error/configure.rb). This is to prevent temporary test environments from flooding our Sentry account with errors.
+
+You can add your environment to the list of active Sentry environments like so:
+
+```ruby
+GovukError.configure do |config|
+  config.active_sentry_environments << "my-test-environment"
+end
 ```
 
 ### Error configuration

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -3,25 +3,38 @@ require "govuk_app_config/govuk_error/govuk_data_sync"
 
 module GovukError
   class Configuration < SimpleDelegator
-    attr_reader :data_sync
-    attr_accessor :data_sync_excluded_exceptions
+    attr_reader :data_sync, :sentry_environment
+    attr_accessor :active_sentry_environments, :data_sync_excluded_exceptions
 
     def initialize(_raven_configuration)
       super
+      @sentry_environment = ENV["SENTRY_CURRENT_ENV"]
       @data_sync = GovukDataSync.new(ENV["GOVUK_DATA_SYNC_PERIOD"])
+      self.active_sentry_environments = []
       self.data_sync_excluded_exceptions = []
-      self.should_capture = ignore_excluded_exceptions_in_data_sync
+      self.should_capture = ignore_exceptions_based_on_env_and_data_sync
     end
 
     def should_capture=(closure)
       combined = lambda do |error_or_event|
-        (ignore_excluded_exceptions_in_data_sync.call(error_or_event) && closure.call(error_or_event))
+        (ignore_exceptions_based_on_env_and_data_sync.call(error_or_event) && closure.call(error_or_event))
       end
 
       super(combined)
     end
 
   protected
+
+    def ignore_exceptions_based_on_env_and_data_sync
+      lambda do |error_or_event|
+        ignore_exceptions_if_not_in_active_sentry_env.call(error_or_event) &&
+          ignore_excluded_exceptions_in_data_sync.call(error_or_event)
+      end
+    end
+
+    def ignore_exceptions_if_not_in_active_sentry_env
+      ->(_error_or_event) { active_sentry_environments.include?(sentry_environment) }
+    end
 
     def ignore_excluded_exceptions_in_data_sync
       lambda { |error_or_event|

--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -7,6 +7,16 @@ GovukError.configure do |config|
 
   config.silence_ready = !Rails.env.production? if defined?(Rails)
 
+  # These are the environments (described by the `SENTRY_CURRENT_ENV`
+  # ENV variable) where we want to capture Sentry errors. If
+  # `SENTRY_CURRENT_ENV` isn't in this list, or isn't defined, then
+  # don't capture the error.
+  config.active_sentry_environments = %w[
+    integration-blue-aws
+    staging
+    production
+  ]
+
   config.excluded_exceptions = [
     # Default ActionDispatch rescue responses
     "ActionController::RoutingError",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.5.2".freeze
+  VERSION = "2.6.0".freeze
 end


### PR DESCRIPTION
We sometimes spin up temporary environments (e.g. 'test-pink-aws')
while developing applications. If there are errors in those apps,
we can accidentally send many thousands of errors to Sentry, which
can mean we hit rate limits on our other, production,
environments, as we have a single shared Sentry account.

This commit introduces a `active_sentry_environments` config
property, which is checked against the SENTRY_CURRENT_ENV ENV
variable. If an error occurs in an environment we care about,
it is reported to Sentry, otherwise it gets ignored.

There is prior art for this - in #160 we added a similar check,
such that if a particular error occurs during the nightly data
sync, it gets ignored. I've made sure this new functionality is
compatible with what's already been added.

Trello: https://trello.com/c/GfFwJG0K/2180-investigate-disabling-sentry-on-environments-we-dont-care-about-timebox-2-days