### PR TITLE
Ignore intermittent retrieval errors from Slimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.7.0
+
+* Ignore intermittent template retrieval errors from Slimmer
+
 # 2.6.0
 
 * Ignore errors that occur in temporary environments (adds `active_sentry_environments` config) (https://github.com/alphagov/govuk_app_config/pull/168)

--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -46,6 +46,7 @@ GovukError.configure do |config|
     "GdsApi::TimedOutException",
     "Mongoid::Errors::DocumentNotFound",
     "Sinatra::NotFound",
+    "Slimmer::IntermittentRetrievalError",
   ]
 
   # This will exclude exceptions that are triggered by one of the ignored

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.6.0".freeze
+  VERSION = "2.7.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/qqGgd6mA/598-dev-pain-slimmer-causes-500-errors-for-transient-communication-errors-with-static

Related to: https://github.com/alphagov/slimmer/pull/257