### PR TITLE
Remove Remote IP middleware for all apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.8.0
+
+* Turn off redundant RemoteIp middleware for all apps
+
 # 2.7.0
 
 * Ignore intermittent template retrieval errors from Slimmer

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -3,5 +3,14 @@ module GovukAppConfig
     config.before_initialize do
       GovukLogging.configure if Rails.env.production?
     end
+
+    # Avoid relying on dodgy HTTP headers about the requester's IP:
+    # https://blog.gingerlime.com/2012/rails-ip-spoofing-vulnerabilities-and-protection/
+    #
+    # Protection of GOV.UK should be implemented at the network level:
+    # https://github.com/alphagov/govuk-cdn-config/blob/2c8b87fd6d1bef7067ea872f7232c53effbf31b4/vcl_templates/www.vcl.erb#L203
+    initializer "govuk_app_config.remove_remote_ip" do |app|
+      app.middleware.delete ActionDispatch::RemoteIp
+    end
   end
 end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.7.0".freeze
+  VERSION = "2.8.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/7qWgBlA7/617-investigate-handling-actiondispatchremoteipipspoofattackerror

This is unreliable and we only use it in Signon, although even there
it's unclear why it's necessary [1]. Recently we have seen this lead
to Sentry issues where the middleware irrelevantly detects a dodgy
set of headers in the request [2].

[1]: https://github.com/alphagov/signon/pull/1134
[2]: https://sentry.io/organizations/govuk/issues/1703518396/?project=202221