### PR TITLE
Fix using non-existent Rails method

### DIFF
--- a/lib/govuk_app_config/govuk_error/govuk_data_sync.rb
+++ b/lib/govuk_app_config/govuk_error/govuk_data_sync.rb
@@ -28,7 +28,7 @@ module GovukError
     end
 
     def in_progress?
-      from.present? && to.present? && in_time_range?(from, to)
+      !from.nil? && !to.nil? && in_time_range?(from, to)
     end
 
   private


### PR DESCRIPTION
Previously we used ".present?" to check for from/to attributes, but
these methods are only available in Rails app. This switches to using
standard library methods to ensure the code works in all our apps.

Example error:

Uncaught exception from consumer #<Bunny::Consumer:50260 @channel_id=1 @queue=email_unpublishing>
@consumer_tag=bunny-1606752847000-821140807868>: #<NoMethodError: undefined method `present?'
for 2020-11-30 22:00:00 +0000:Time> @ /data/vhost/email-alert-service/shared/bundle/ruby/2.7.0/
gems/govuk_app_config-2.7.0/lib/govuk_app_config/govuk_error/govuk_data_sync.rb:31:in `in_progress?'