### PR TITLE
Add GdsApi::ContentStore::ItemNotFound to data_sync_excluded_exceptions

### DIFF
--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -61,6 +61,7 @@ GovukError.configure do |config|
   # rate-limited by Sentry.
   config.data_sync_excluded_exceptions = [
     "PG::Error",
+    "GdsApi::ContentStore::ItemNotFound",
   ]
 
   config.transport_failure_callback = proc {


### PR DESCRIPTION
We saw a [spike in errors](https://sentry.io/organizations/govuk/issues/2067287240/?project=202252) on
Staging between 1 and 2am (peak datasync time), resulting from Smart Answers requesting items from
the Content Store. These requests seem to correspond with the
[feature test in Smokey](https://github.com/alphagov/smokey/blob/e9b24251e5be5cc6bae5dc0fd8b2820c1d3efbb9/features/smartanswers.feature#L18).

Whilst we should probably consider the merits of continuing to run Smokey during a data sync, more
generally we know not to rely on Content Store during this period, as its DB gets dropped and repopulated
with production data. So `GdsApi::ContentStore::ItemNotFound` errors seem a good candidate for ignoring
during the data sync period.