### PR TITLE
Permit apps to send messages to Statsd over TCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow apps to configure the host and protocol for Statsd ([#180](https://github.com/alphagov/govuk_app_config/pull/180))
+
 # 2.8.1
 
 * Add `GdsApi::ContentStore::ItemNotFound` to `data_sync_excluded_exceptions` (https://github.com/alphagov/govuk_app_config/pull/178)

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
   spec.add_dependency "sentry-raven", "~> 3.1.1"
-  spec.add_dependency "statsd-ruby", "~> 1.4.0"
+  spec.add_dependency "statsd-ruby-tcp", "~> 0.1.2"
   spec.add_dependency "unicorn", ">= 5.4", "< 5.9"
 
   spec.add_development_dependency "byebug"

--- a/lib/govuk_app_config/govuk_statsd.rb
+++ b/lib/govuk_app_config/govuk_statsd.rb
@@ -8,7 +8,7 @@ module GovukStatsd
 
   def self.client
     @client ||= begin
-      statsd_client = ::Statsd.new("localhost")
+      statsd_client = ::Statsd.new(ENV["GOVUK_STATSD_HOST"] || "localhost", 8125, ENV["GOVUK_STATSD_PROTOCOL"]&.to_sym || :udp)
       statsd_client.namespace = ENV["GOVUK_STATSD_PREFIX"].to_s
       statsd_client
     end

--- a/lib/govuk_app_config/govuk_statsd.rb
+++ b/lib/govuk_app_config/govuk_statsd.rb
@@ -1,4 +1,4 @@
-require "statsd"
+require "statsd-ruby-tcp"
 require "forwardable"
 
 module GovukStatsd
@@ -8,7 +8,7 @@ module GovukStatsd
 
   def self.client
     @client ||= begin
-      statsd_client = ::Statsd.new(ENV["GOVUK_STATSD_HOST"] || "localhost", 8125, ENV["GOVUK_STATSD_PROTOCOL"]&.to_sym || :udp)
+      statsd_client = ::StatsdTcp.new(ENV["GOVUK_STATSD_HOST"] || "localhost", 8125, ENV["GOVUK_STATSD_PROTOCOL"]&.to_sym || :udp)
       statsd_client.namespace = ENV["GOVUK_STATSD_PREFIX"].to_s
       statsd_client
     end


### PR DESCRIPTION
This enables apps to specify both the host and protocol to use when sending metrics to Statsd.

This change is required for apps running in ECS, since Statsd won't run on localhost and [apps won't send messages to Statsd over UDP](https://github.com/aws/aws-app-mesh-roadmap/issues/57).

This should have no effect on apps currently running in EC2. The defaults `"localhost"` and `:udp` aren't required, since they duplicate [the defaults in the Statsd gem](https://github.com/reinh/statsd/blob/master/lib/statsd.rb#L294) - I've put them in for clarity.

This also temporarily drops in a new Statsd client. This gem (published by me) is my fork of our current client but with [this PR merged in](https://github.com/reinh/statsd/pull/77) - I'll switch the gem back once my PR is merged in.