### PR TITLE
Use statsd-ruby 1.5 client

### DIFF
--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
   spec.add_dependency "sentry-raven", "~> 3.1.1"
-  spec.add_dependency "statsd-ruby-tcp", "~> 0.1.2"
+  spec.add_dependency "statsd-ruby", "~> 1.5.0"
   spec.add_dependency "unicorn", ">= 5.4", "< 5.9"
 
   spec.add_development_dependency "byebug"

--- a/lib/govuk_app_config/govuk_statsd.rb
+++ b/lib/govuk_app_config/govuk_statsd.rb
@@ -1,4 +1,4 @@
-require "statsd-ruby-tcp"
+require "statsd"
 require "forwardable"
 
 module GovukStatsd
@@ -8,7 +8,7 @@ module GovukStatsd
 
   def self.client
     @client ||= begin
-      statsd_client = ::StatsdTcp.new(ENV["GOVUK_STATSD_HOST"] || "localhost", 8125, ENV["GOVUK_STATSD_PROTOCOL"]&.to_sym || :udp)
+      statsd_client = ::Statsd.new(ENV["GOVUK_STATSD_HOST"] || "localhost", 8125, ENV["GOVUK_STATSD_PROTOCOL"]&.to_sym || :udp)
       statsd_client.namespace = ENV["GOVUK_STATSD_PREFIX"].to_s
       statsd_client
     end


### PR DESCRIPTION
This partially reverts https://github.com/alphagov/govuk_app_config/pull/180 and starts using the latest version ([1.5](https://rubygems.org/gems/statsd-ruby)) of the statsd client, which fixes TCP support.

The statsd client we were using was a temporary replacement for statsd-ruby - see the other PR for details.