### PR TITLE
Bump gem version to 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.8.2
 
 * Allow apps to configure the host and protocol for Statsd ([#180](https://github.com/alphagov/govuk_app_config/pull/180))
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "2.8.1".freeze
+  VERSION = "2.8.2".freeze
 end


### PR DESCRIPTION
This release will allow apps to configure the host and protocol for Statsd.