### PR TITLE
Adds plural rules not available in i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ app with the following content:
 GovukContentSecurityPolicy.configure
 ```
 
+## i18n rules 
+
+Some frontend apps support languages that are not defined in the i18n gem. This provides them with our own custom rules for these languages.
+
 ## License
 
 [MIT License](LICENSE.md)

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -3,6 +3,7 @@ require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_error/configure"
 require "govuk_app_config/govuk_healthcheck"
+require "govuk_app_config/govuk_i18n"
 # This require is deprecated and should be removed on next major version bump
 # and should be required by applications directly.
 require "govuk_app_config/govuk_unicorn"

--- a/lib/govuk_app_config/govuk_i18n.rb
+++ b/lib/govuk_app_config/govuk_i18n.rb
@@ -1,0 +1,38 @@
+module GovukI18n
+  def plurals
+    {
+      # Dari - this isn't an iso code. Probably should be 'prs' as per ISO 639-3.
+      dr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Latin America and Caribbean Spanish
+      "es-419": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Scottish Gaelic
+      gd: { i18n: { plural: { keys: %i[one two few other],
+                              rule:
+                                lambda do |n|
+                                  if [1, 11].include?(n)
+                                    :one
+                                  elsif [2, 12].include?(n)
+                                    :two
+                                  elsif [3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19].include?(n)
+                                    :few
+                                  else
+                                    :other
+                                  end
+                                end } } },
+      # Armenian
+      hy: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Kazakh
+      kk: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Punjabi Shahmukhi
+      "pa-pk": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Sinhalese
+      si: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Uzbek
+      uz: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Chinese Hong Kong
+      "zh-hk" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Chinese Taiwan
+      "zh-tw" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+    }
+  end
+end


### PR DESCRIPTION
We have these rules in four different apps so moving them to one place
to make it easier to maintain.

https://trello.com/c/eEphXlio/2394-5-check-and-update-rules-for-plural-forms-across-frontend-apps