### PR TITLE
Allow LUX domain on img-src policy

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -32,7 +32,10 @@ module GovukContentSecurityPolicy
                    *GOVUK_DOMAINS,
                    *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
                    # Some content still links to an old domain we used to use
-                   "assets.digital.cabinet-office.gov.uk"
+                   "assets.digital.cabinet-office.gov.uk",
+                   # Allow images to be loaded for Speedcurve's LUX - used for
+                   # getting real user metrics on GOV.UK
+                   "lux.speedcurve.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     policy.script_src :self,


### PR DESCRIPTION
## What

Adds `lux.speedcurve.com` to the img-src allow list.

Needed for https://github.com/alphagov/static/pull/2445 to work.

## Why

This will allow Speedcurve's real user metrics service, called LUX, to load an image beacon that will send real user metrics back to the service.