### PR TITLE
Explitly ignore UndefinedTable and StatementInvalid exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.2
+
+- Attempt to fix the `before_send` behaviour for errors which occur during the data sync ([#198](https://github.com/alphagov/govuk_app_config/pull/198))
+
 # 3.1.1
 
 - Fix the new before_send behaviour & tests, and add documentation ([#197](https://github.com/alphagov/govuk_app_config/pull/197))

--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -55,6 +55,8 @@ GovukError.configure do |config|
   # rate-limited by Sentry.
   config.data_sync_excluded_exceptions = [
     "PG::Error",
+    "PG::UndefinedTable",
+    "ActiveRecord::StatementInvalid",
     "GdsApi::ContentStore::ItemNotFound",
   ]
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "3.1.1".freeze
+  VERSION = "3.1.2".freeze
 end


### PR DESCRIPTION
Since #196 and #197, we're seeing errors in Sentry during the
data sync where we have configured these to be ignored. Example:

https://sentry.io/organizations/govuk/issues/2410319407/?project=202210&referrer=slack

The exception chain in the above Sentry error contains
`ActiveRecord::StatementInvalid` and `PG::UndefinedTable`. We have
`PG::Error` defined as a datasync-ignorable exception by default.
[`PG::UndefinedTable` has `PG::Error` as an ancestor](https://github.com/ged/ruby-pg/blob/00cb2ecfaa70470234ee83efbd942b5e6ea0f4ea/spec/pg_spec.rb#L35-L39),
so it should be ignoring the exception.

To determine whether the exception chain introspection is broken,
we're explicitly adding these exception types to the ignore list.
If the errors continue to occur, then the issue is elsewhere.

For the record, I've also SSH'd into the machine on Integration
and ran `cat /etc/govuk/env.d/GOVUK_DATA_SYNC_PERIOD`, which has
a value of "22:0-8:0". This, despite its dodgy formatting, does
get interpreted correctly by GovukDataSync, therefore I am fairly
certain that [`data_sync.in_progress?`](https://github.com/alphagov/govuk_app_config/blob/2616f571fdb28d1ee78c8983b257c16fc64a4994/lib/govuk_app_config/govuk_error/configuration.rb#L45)
returns `true` when called during the data sync.
Moreover, there have been no relevant changes in govuk-puppet to suggest that the data sync ENV variable could be the cause.