### PR TITLE
v4 pre-release: upgrade sentry-raven to sentry-ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.0.pre-1
+
+- BREAKING: upgrades Sentry gem from `sentry-raven` to `sentry-ruby` ([#199](https://github.com/alphagov/govuk_app_config/pull/199)). There is a **[migration guide](https://docs.sentry.io/platforms/ruby/migration/)** you should follow before upgrading to this version of govuk_app_config.
+- This release also fixes the `data_sync_excluded_exceptions` behaviour that has been broken since v3.1.0.
+- Released as a pre-release to identify and fix any problems before a wider rollout.
+
 # 3.1.1
 
 - Fix the new before_send behaviour & tests, and add documentation ([#197](https://github.com/alphagov/govuk_app_config/pull/197))

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ and occurs at the time of a data sync, then it will be excluded even if the cust
 
 ```ruby
 GovukError.configure do |config|
-  config.before_send = lambda do |error_or_event|
-    error_or_event == "do capture" ? error_or_event : nil
+  config.before_send = lambda do |event, hint|
+    hint[:exception].is_a?(ErrorWeWantToIgnore) ? nil : event
   end
 end
 ```

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
-  spec.add_dependency "sentry-raven", "~> 3.1.1"
+  spec.add_dependency "sentry-ruby", "~> 4.5.0"
   spec.add_dependency "statsd-ruby", "~> 1.5.0"
   spec.add_dependency "unicorn", ">= 5.4", "< 5.9"
 

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -17,7 +17,7 @@ module GovukError
   end
 
   def self.configure
-    @configuration ||= Configuration.new(Sentry.configuration)
+    @configuration ||= Configuration.new(Sentry::Configuration.new)
     yield @configuration
   end
 end

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -1,4 +1,4 @@
-require "sentry-raven"
+require "sentry-ruby"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error/configuration"
 require "govuk_app_config/version"
@@ -13,11 +13,11 @@ module GovukError
     args[:tags] ||= {}
     args[:tags][:govuk_app_config_version] = GovukAppConfig::VERSION
 
-    Raven.capture_exception(exception_or_message, args)
+    Sentry.capture_exception(exception_or_message, args)
   end
 
   def self.configure
-    @configuration ||= Configuration.new(Raven.configuration)
+    @configuration ||= Configuration.new(Sentry.configuration)
     yield @configuration
   end
 end

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -6,7 +6,7 @@ module GovukError
     attr_reader :data_sync, :sentry_environment
     attr_accessor :active_sentry_environments, :data_sync_excluded_exceptions
 
-    def initialize(_raven_configuration)
+    def initialize(_sentry_configuration)
       super
       @sentry_environment = ENV["SENTRY_CURRENT_ENV"]
       @data_sync = GovukDataSync.new(ENV["GOVUK_DATA_SYNC_PERIOD"])
@@ -34,7 +34,7 @@ module GovukError
       lambda { |error_or_event, _hint|
         data_sync_ignored_error = data_sync_excluded_exceptions.any? do |exception_to_ignore|
           exception_to_ignore = Object.const_get(exception_to_ignore) unless exception_to_ignore.is_a?(Module)
-          exception_chain = Raven::Utils::ExceptionCauseChain.exception_to_array(error_or_event)
+          exception_chain = Sentry::Utils::ExceptionCauseChain.exception_to_array(error_or_event)
           exception_chain.any? { |exception| exception.is_a?(exception_to_ignore) }
         rescue NameError
           # the exception type represented by the exception_to_ignore string

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -50,7 +50,7 @@ module GovukError
       lambda { |event, hint|
         if hint[:exception]
           GovukStatsd.increment("errors_occurred")
-          GovukStatsd.increment("error_types.#{hint[:exception].class.name.demodulize.underscore}")
+          GovukStatsd.increment("error_types.#{hint[:exception].class.name.split('::').last.underscore}")
         end
         event
       }

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -27,14 +27,14 @@ module GovukError
   protected
 
     def ignore_exceptions_if_not_in_active_sentry_env
-      ->(error_or_event, _hint) { error_or_event if active_sentry_environments.include?(sentry_environment) }
+      ->(event, _hint) { event if active_sentry_environments.include?(sentry_environment) }
     end
 
     def ignore_excluded_exceptions_in_data_sync
-      lambda { |error_or_event, _hint|
+      lambda { |event, hint|
         data_sync_ignored_error = data_sync_excluded_exceptions.any? do |exception_to_ignore|
           exception_to_ignore = Object.const_get(exception_to_ignore) unless exception_to_ignore.is_a?(Module)
-          exception_chain = Sentry::Utils::ExceptionCauseChain.exception_to_array(error_or_event)
+          exception_chain = Sentry::Utils::ExceptionCauseChain.exception_to_array(hint[:exception])
           exception_chain.any? { |exception| exception.is_a?(exception_to_ignore) }
         rescue NameError
           # the exception type represented by the exception_to_ignore string
@@ -42,23 +42,23 @@ module GovukError
           false
         end
 
-        error_or_event unless data_sync.in_progress? && data_sync_ignored_error
+        event unless data_sync.in_progress? && data_sync_ignored_error
       }
     end
 
     def increment_govuk_statsd_counters
-      lambda { |error_or_event, _hint|
+      lambda { |event, hint|
         GovukStatsd.increment("errors_occurred")
-        GovukStatsd.increment("error_types.#{error_or_event.class.name.demodulize.underscore}")
-        error_or_event
+        GovukStatsd.increment("error_types.#{hint[:exception].class.name.demodulize.underscore}")
+        event
       }
     end
 
     def run_before_send_callbacks
-      lambda do |error_or_event, hint|
-        result = error_or_event
+      lambda do |event, hint|
+        result = event
         @before_send_callbacks.each do |callback|
-          result = callback.call(error_or_event, hint)
+          result = callback.call(event, hint)
           break if result.nil?
         end
         result

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -48,8 +48,10 @@ module GovukError
 
     def increment_govuk_statsd_counters
       lambda { |event, hint|
-        GovukStatsd.increment("errors_occurred")
-        GovukStatsd.increment("error_types.#{hint[:exception].class.name.demodulize.underscore}")
+        if hint[:exception]
+          GovukStatsd.increment("errors_occurred")
+          GovukStatsd.increment("error_types.#{hint[:exception].class.name.demodulize.underscore}")
+        end
         event
       }
     end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "3.1.1".freeze
+  VERSION = "4.0.0.pre.1".freeze
 end

--- a/spec/govuk_error/configuration_spec.rb
+++ b/spec/govuk_error/configuration_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "sentry-raven"
+require "sentry-ruby"
 require "govuk_app_config/govuk_error/configuration"
 
 RSpec.describe GovukError::Configuration do

--- a/spec/govuk_error/configuration_spec.rb
+++ b/spec/govuk_error/configuration_spec.rb
@@ -181,6 +181,21 @@ RSpec.describe GovukError::Configuration do
         end
       end
     end
+
+    context "when a message rather than an exception is sent to Sentry" do
+      it "does not increment the error counters" do
+        ClimateControl.modify SENTRY_CURRENT_ENV: "production" do
+          configuration.active_sentry_environments << "production"
+          sentry_client = Sentry::Client.new(optimise_configuration_for_testing(configuration))
+          sentry_hub = Sentry::Hub.new(sentry_client, Sentry::Scope.new)
+
+          expect(GovukStatsd).to receive(:increment).exactly(0).times
+          expect(GovukStatsd).to receive(:increment).exactly(0).times
+
+          sentry_hub.capture_message("foo")
+        end
+      end
+    end
   end
 
   describe ".before_send=" do

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -4,32 +4,32 @@ require "govuk_app_config/govuk_error"
 RSpec.describe GovukError do
   describe ".notify" do
     it "forwards the exception" do
-      allow(Raven).to receive(:capture_exception)
+      allow(Sentry).to receive(:capture_exception)
 
       GovukError.notify(StandardError.new)
 
-      expect(Raven).to have_received(:capture_exception)
+      expect(Sentry).to have_received(:capture_exception)
     end
 
     it "allows Airbrake-style parameters" do
-      allow(Raven).to receive(:capture_exception)
+      allow(Sentry).to receive(:capture_exception)
 
       GovukError.notify(StandardError.new, parameters: "Something")
 
-      expect(Raven).to have_received(:capture_exception).with(StandardError.new, hash_including(extra: { parameters: "Something" }))
+      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(extra: { parameters: "Something" }))
     end
 
     it "sends the version along with the request" do
-      allow(Raven).to receive(:capture_exception)
+      allow(Sentry).to receive(:capture_exception)
 
       GovukError.notify(StandardError.new, parameters: "Something")
 
-      expect(Raven).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^[0-9.]+$/ }))
+      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^[0-9.]+$/ }))
     end
   end
 
   describe ".configure" do
-    it "configures Raven via the Configuration" do
+    it "configures Sentry via the Configuration" do
       expect { |b| GovukError.configure(&b) }
         .to yield_with_args(instance_of(GovukError::Configuration))
     end

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GovukError do
 
       GovukError.notify(StandardError.new, parameters: "Something")
 
-      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^[0-9.]+$/ }))
+      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^[0-9]\.[0-9]\.[0-9](?:\.pre\.[0-9]+)?$/ }))
     end
   end
 


### PR DESCRIPTION
On 10 December 2020, `sentry-raven` was [deprecated](https://github.com/getsentry/sentry-ruby/tree/master/sentry-raven) and renamed to [`sentry-ruby`](https://github.com/getsentry/sentry-ruby) (which is essentially `sentry-raven` "v4"). `sentry-raven` will [no longer receive any support or bug fixes](https://github.com/getsentry/sentry-ruby/blame/master/sentry-raven/README.md#L18).

The benefits of moving to `sentry-ruby` include:

- Unified interface with other SDKs (i.e. documentation that used to be irrelevant will now be relevant!)
- performance monitoring (though [this isn't included in our plan](https://sentry.io/organizations/govuk/performance/))
- "better extensibility... will allow the community to build extensions for different integrations/features".  (It's not clear what benefits that might bring just yet.)

This PR also fixes the `data_sync_excluded_exceptions` behaviour that has been broken since v3.1.0. See commits for details.

Trello: https://trello.com/c/1zVPYfTR/2539-3-replace-sentry-raven-with-sentry-ruby-in-govukappconfig