### PR TITLE
Incorporate latest rubocop rules

### DIFF
--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -15,9 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/alphagov/govuk_app_config"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.6"
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/lib/govuk_app_config/govuk_error/govuk_data_sync.rb
+++ b/lib/govuk_app_config/govuk_error/govuk_data_sync.rb
@@ -3,14 +3,8 @@ require "time"
 module GovukError
   class GovukDataSync
     class MalformedDataSyncPeriod < RuntimeError
-      attr_reader :invalid_value
-
       def initialize(invalid_value)
-        @invalid_value = invalid_value
-      end
-
-      def message
-        "\"#{invalid_value}\" is not a valid value (should be of form '22:00-03:00')."
+        super("\"#{invalid_value}\" is not a valid value (should be of form '22:00-03:00').")
       end
     end
 

--- a/spec/govuk_error/govuk_data_sync_spec.rb
+++ b/spec/govuk_error/govuk_data_sync_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe GovukError::GovukDataSync do
     end
   end
 
-  def at(time)
-    travel_to(Time.current.change(time)) do
-      yield
-    end
+  def at(time, &block)
+    travel_to(Time.current.change(time), &block)
   end
 end

--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -3,7 +3,11 @@ require "rails"
 require "govuk_app_config/govuk_content_security_policy"
 
 RSpec.describe GovukContentSecurityPolicy do
-  class DummyCspRailsApp < Rails::Application; end
+  before do
+    stub_const("DummyCspRailsApp", Class.new(Rails::Application))
+  end
+
+  after { Rails.application = nil }
 
   describe ".configure" do
     it "creates a policy" do

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -4,12 +4,16 @@ require "govuk_app_config/govuk_logging"
 require "rack/test"
 
 RSpec.describe GovukLogging do
-  class DummyLoggingRailsApp < Rails::Application
-    config.hosts.clear
-    routes.draw do
-      get "/error", to: proc { |_env| raise StandardError, "default exception" }
-    end
+  before do
+    stub_const("DummyLoggingRailsApp", Class.new(Rails::Application) do
+      config.hosts.clear
+      routes.draw do
+        get "/error", to: proc { |_env| raise StandardError, "default exception" }
+      end
+    end)
   end
+
+  after { Rails.application = nil }
 
   old_stderr = nil
 
@@ -62,6 +66,7 @@ RSpec.describe GovukLogging do
 
     describe "when making requests to the application" do
       include Rack::Test::Methods
+
       def app
         Rails.application
       end

--- a/spec/lib/govuk_logging_spec.rb
+++ b/spec/lib/govuk_logging_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GovukLogging do
   class DummyLoggingRailsApp < Rails::Application
     config.hosts.clear
     routes.draw do
-      get "/error", to: proc { |_env| raise Exception, "default exception" }
+      get "/error", to: proc { |_env| raise StandardError, "default exception" }
     end
   end
 
@@ -76,7 +76,7 @@ RSpec.describe GovukLogging do
         expect(error_log_line).not_to be_empty
         error_log_json = JSON.parse(error_log_line)
         expect(error_log_json).to match(hash_including(
-                                          "exception_class" => "Exception",
+                                          "exception_class" => "StandardError",
                                           "exception_message" => "default exception",
                                         ))
         expect(error_log_json).to have_key("stacktrace")

--- a/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
@@ -10,38 +10,34 @@ RSpec.describe ::GovukLogging::RailsExt::ActionDispatch do
     end
 
     it "should not monkey patch classes which do not have log_error" do
-      class NoMethodTestClass; end
-      expect(described_class.should_monkey_patch_log_error?(NoMethodTestClass)).to be(false)
+      no_method_test_class = Class.new
+      expect(described_class.should_monkey_patch_log_error?(no_method_test_class)).to be(false)
     end
 
     it "should not monkey patch classes which have log_error with different params" do
-      class WrongParametersTestClass
-      private
-
+      wrong_parameters_test_class = Class.new do
         def log_error(_different, _parameters); end
       end
-      expect(described_class.should_monkey_patch_log_error?(WrongParametersTestClass)).to be(false)
+      expect(described_class.should_monkey_patch_log_error?(wrong_parameters_test_class)).to be(false)
     end
 
     it "should monkey patch classes which have log_error with the same params" do
-      class RightParametersTestClass
-      private
-
+      right_parameters_test_class = Class.new do
         def log_error(request, wrapper); end
       end
-      expect(described_class.should_monkey_patch_log_error?(RightParametersTestClass)).to be(false)
+      expect(described_class.should_monkey_patch_log_error?(right_parameters_test_class)).to be(false)
     end
   end
 
   describe "#monkey_patch_log_error" do
     it "should replace the private log_error method" do
-      class FakeDebugExceptions
+      fake_debug_exceptions = Class.new do
         def log_error(request, wrapper); end
       end
-      instance = FakeDebugExceptions.new
+      instance = fake_debug_exceptions.new
 
       expect {
-        described_class.monkey_patch_log_error(FakeDebugExceptions)
+        described_class.monkey_patch_log_error(fake_debug_exceptions)
       }.to(change { instance.method(:log_error) })
     end
   end


### PR DESCRIPTION
Upgrading rubocop-govuk to version 4 (via running `bundle update` locally) introduces some new rules we need to account for.

We've had to specify a minimum Ruby version, which we have set as 2.6.5 in `.ruby-version`, so I've used that as the basis.
Then it's mostly warnings about declaring classes within tests. Where possible, I've swapped these out for `stub_const`, but we have several tests which rely heavily on the internals of class declaration, inheritence, method overloading and the like, and it seemed less expressive to try to convert these in a way that appeased the linter. I've therefore added some lint-ignore
declarations inline in these files.