### PR TITLE
Query the original exception rather than Sentry::Event object

### DIFF
--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -27,14 +27,14 @@ module GovukError
   protected
 
     def ignore_exceptions_if_not_in_active_sentry_env
-      ->(error_or_event, _hint) { error_or_event if active_sentry_environments.include?(sentry_environment) }
+      ->(event, _hint) { event if active_sentry_environments.include?(sentry_environment) }
     end
 
     def ignore_excluded_exceptions_in_data_sync
-      lambda { |error_or_event, _hint|
+      lambda { |event, hint|
         data_sync_ignored_error = data_sync_excluded_exceptions.any? do |exception_to_ignore|
           exception_to_ignore = Object.const_get(exception_to_ignore) unless exception_to_ignore.is_a?(Module)
-          exception_chain = Sentry::Utils::ExceptionCauseChain.exception_to_array(error_or_event)
+          exception_chain = Sentry::Utils::ExceptionCauseChain.exception_to_array(hint[:exception])
           exception_chain.any? { |exception| exception.is_a?(exception_to_ignore) }
         rescue NameError
           # the exception type represented by the exception_to_ignore string
@@ -42,23 +42,23 @@ module GovukError
           false
         end
 
-        error_or_event unless data_sync.in_progress? && data_sync_ignored_error
+        event unless data_sync.in_progress? && data_sync_ignored_error
       }
     end
 
     def increment_govuk_statsd_counters
-      lambda { |error_or_event, _hint|
+      lambda { |event, hint|
         GovukStatsd.increment("errors_occurred")
-        GovukStatsd.increment("error_types.#{error_or_event.class.name.demodulize.underscore}")
-        error_or_event
+        GovukStatsd.increment("error_types.#{hint[:exception].class.name.demodulize.underscore}")
+        event
       }
     end
 
     def run_before_send_callbacks
-      lambda do |error_or_event, hint|
-        result = error_or_event
+      lambda do |event, hint|
+        result = event
         @before_send_callbacks.each do |callback|
-          result = callback.call(error_or_event, hint)
+          result = callback.call(event, hint)
           break if result.nil?
         end
         result


### PR DESCRIPTION
In the `before_send` callbacks, the first parameter is of type `Sentry::Event`, and the second parameter (`hint`) is a hash which contains the original exception at key `exception`.

Our datasync-ignorable-exception logic relies on querying the exception chain to see if any of the exceptions in the chain are
of an ignorable exception type. This logic doesn't work when we view the `Sentry::Event` object (as we have been doing) - we must instead look at the `hint[:exception]` object.

The consequence of this bug was that our logic to ignore certain exceptions that occur during the datasync, no longer worked, and we've therefore seen many thousands of Sentry errors since #196 was merged.

However, it wasn't as simple as just checking the `hint` parameter. The `hint` parameter was missing, due to the way we had constructed our tests. Sentry automatically provides the `hint` parameter, but only if the event has been sent through all of the layers of Sentry's architecture, which took a bit of trial and error to get right. I took inspiration from [hub_spec.rb] and [sentry_spec.rb] from the Sentry gem repository.

This has also exposed how our GovukStatsd incrementing was not working, as it would log all errors as `error_types.sentry_event` rather than their original exception types. This is fixed too.

[hub_spec.rb]: https://github.com/getsentry/sentry-ruby/blob/e4b6d66612d9ce601596c23a5dd0d035c559d980/sentry-ruby/spec/sentry/hub_spec.rb
[sentry_spec.rb]: https://github.com/getsentry/sentry-ruby/blob/ace176cfceaefc91e29364a1c4180a67337e8ab0/sentry-ruby/spec/sentry_spec.rb

Trello: https://trello.com/c/4JOuje6O/2546-fix-broken-data-sync-related-sentry-errors-not-being-ignored