### PR TITLE
Release 4.0.0.pre.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.0.pre-2
+
+- Fix default Sentry configuration ([#202](https://github.com/alphagov/govuk_app_config/pull/202)).
+- BREAKING: this means no more `silence_ready` or `transport_failure_callback` options.
+
 # 4.0.0.pre-1
 
 - BREAKING: upgrades Sentry gem from `sentry-raven` to `sentry-ruby` ([#199](https://github.com/alphagov/govuk_app_config/pull/199)). There is a **[migration guide](https://docs.sentry.io/platforms/ruby/migration/)** you should follow before upgrading to this version of govuk_app_config.

--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -1,6 +1,4 @@
 GovukError.configure do |config|
-  config.silence_ready = !Rails.env.production? if defined?(Rails)
-
   # These are the environments (described by the `SENTRY_CURRENT_ENV`
   # ENV variable) where we want to capture Sentry errors. If
   # `SENTRY_CURRENT_ENV` isn't in this list, or isn't defined, then

--- a/lib/govuk_app_config/govuk_error/configure.rb
+++ b/lib/govuk_app_config/govuk_error/configure.rb
@@ -61,8 +61,4 @@ GovukError.configure do |config|
   config.before_send = lambda { |error_or_event, _hint|
     error_or_event
   }
-
-  config.transport_failure_callback = proc {
-    GovukStatsd.increment("error_reports_failed")
-  }
 end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.0.0.pre.1".freeze
+  VERSION = "4.0.0.pre.2".freeze
 end

--- a/spec/govuk_error/configure_spec.rb
+++ b/spec/govuk_error/configure_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+require "sentry-ruby"
+require "govuk_app_config/govuk_error"
+
+RSpec.describe "GovukError.configure" do
+  it "should contain only valid Sentry config" do
+    require "govuk_app_config/govuk_error/configure"
+  end
+end


### PR DESCRIPTION
Attempting to pull govuk_app_config v4.0.0.pre.1 into a project led to a failure, because our default Sentry configuration is
currently invalid. This is now fixed up, and tests added to prevent that happening again.