### PR TITLE
Release 4.0.0.pre.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# 4.0.0.pre-2
+# 4.0.0.pre.3
+
+- Include [sentry-rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails) by default ([#203](https://github.com/alphagov/govuk_app_config/pull/203)).
+
+# 4.0.0.pre.2
 
 - Fix default Sentry configuration ([#202](https://github.com/alphagov/govuk_app_config/pull/202)).
 - BREAKING: this means no more `silence_ready` or `transport_failure_callback` options.
 
-# 4.0.0.pre-1
+# 4.0.0.pre.1
 
 - BREAKING: upgrades Sentry gem from `sentry-raven` to `sentry-ruby` ([#199](https://github.com/alphagov/govuk_app_config/pull/199)). There is a **[migration guide](https://docs.sentry.io/platforms/ruby/migration/)** you should follow before upgrading to this version of govuk_app_config.
 - This release also fixes the `data_sync_excluded_exceptions` behaviour that has been broken since v3.1.0.

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
+  spec.add_dependency "sentry-rails", "~> 4.5.0"
   spec.add_dependency "sentry-ruby", "~> 4.5.0"
   spec.add_dependency "statsd-ruby", "~> 1.5.0"
   spec.add_dependency "unicorn", ">= 5.4", "< 5.9"

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -1,4 +1,5 @@
 require "sentry-ruby"
+require "sentry-rails"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error/configuration"
 require "govuk_app_config/version"

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.0.0.pre.2".freeze
+  VERSION = "4.0.0.pre.3".freeze
 end

--- a/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe ::GovukLogging::RailsExt::ActionDispatch do
       allow(Rails.logger).to receive(:warn)
     end
 
+    after do
+      Rails.logger = nil
+    end
+
     it "should not monkey patch classes which do not have log_error" do
       no_method_test_class = Class.new
       expect(described_class.should_monkey_patch_log_error?(no_method_test_class)).to be(false)


### PR DESCRIPTION
In the major release which renamed sentry-raven to sentry-ruby,
the rails config was extracted into its own sentry-rails gem:
https://docs.sentry.io/platforms/ruby/guides/rails/

I had hoped to have downstream apps explicitly
`require "sentry-rails"` only if they need it, however this means
the code is evaluated too late in the process, as GovukError is
already defined at that point. For example, trying to set
`config.rails.report_rescued_exceptions` in email-alert-api on
govuk_app_config v4.0.0.pre.2 leads to this error:

```
NoMethodError: undefined method `rails' for #<GovukError::Configuration:0x000055d424a1a8d0>
```

It seems the only alternative is to include `sentry-rails` in
GovukAppConfig by default. Most of our apps are Rails apps anyway,
so in practice this should DRY up a bit of configuration across
our apps, as well as making it easier to keep sentry-rails in sync
with sentry-ruby. The only downside is in Rack apps which don't
have Rails, which now have an unnecessary extra dependency - not
a terrible downside in the grand scheme of things.

Depended on by https://github.com/alphagov/email-alert-api/pull/1629.

Trello: https://trello.com/c/4JOuje6O/2546-fix-broken-data-sync-related-sentry-errors-not-being-ignored