### PR TITLE
Add Speedcurve's LUX to connect-src policy

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -78,7 +78,13 @@ module GovukContentSecurityPolicy
                        # Allow JSON call to klick2contact - HMPO web chat provider
                        "gov.klick2contact.com",
                        # Allow connecting to Verify to check whether the user is logged in
-                       "www.signin.service.gov.uk"
+                       "www.signin.service.gov.uk",
+                       # Allow connection to Speedcurve's CDN for LUX - used for
+                       # real user metrics on GOV.UK. This loads using an image
+                       # (see image policy), but returns a JavaScript file -
+                       # which is why this has to be added to the `connect-src`
+                       # policy as well.
+                       "lux.speedcurve.com"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #


### PR DESCRIPTION
Add the domain name that Speedcurve's LUX is using for real user metics - this allows LUX to report on how a page is performing.
