### PR TITLE
Add Changelog entry for 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - This release also fixes the `data_sync_excluded_exceptions` behaviour that has been broken since v3.1.0.
 - Released as a pre-release to identify and fix any problems before a wider rollout.
 
+# 3.2.0
+
+- Add Speedcurve's LUX to connect-src policy ([#206](https://github.com/alphagov/govuk_app_config/pull/206))
+
 # 3.1.1
 
 - Fix the new before_send behaviour & tests, and add documentation ([#197](https://github.com/alphagov/govuk_app_config/pull/197))


### PR DESCRIPTION
This release was published from the CLI from commit
968adf5cada7e2435a4b12ab40455907563a25bd.

It contains the code change from
https://github.com/alphagov/govuk_app_config/pull/206