### PR TITLE
Update reference to klick2contact.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.0.1
 
 - Update Content Security Policy with new klick2contact.com subdomain ([#213](https://github.com/alphagov/govuk_app_config/pull/213)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Update Content Security Policy with new klick2contact.com subdomain ([#213](https://github.com/alphagov/govuk_app_config/pull/213)).
+
 # 4.0.0
 
 - BREAKING: replaces deprecated `sentry-raven` with `sentry-ruby` and `sentry-rails`. Follow the **[migration guide](https://docs.sentry.io/platforms/ruby/migration/)** before upgrading to this version of govuk_app_config to ensure full compatibility with the new gems.

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -76,7 +76,7 @@ module GovukContentSecurityPolicy
                        # Allow JSON call to Nuance - HMRC web chat provider
                        "hmrc-uk.digital.nuance.com",
                        # Allow JSON call to klick2contact - HMPO web chat provider
-                       "gov.klick2contact.com",
+                       "hmpowebchat.klick2contact.com",
                        # Allow connecting to Verify to check whether the user is logged in
                        "www.signin.service.gov.uk",
                        # Allow connection to Speedcurve's CDN for LUX - used for

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.0.0".freeze
+  VERSION = "4.0.1".freeze
 end


### PR DESCRIPTION
Smokey has started failing on `cucumber -p staging_aws features/finder_frontend.feature:90 # Scenario Outline: Check search results and analytics`

This is the error:

```
Refused to connect to 'https://hmpowebchat.klick2contact.com/v03/providers/HMPO/api/availability.php' because it violates the following Content Security Policy directive: "connect-src 'self' *.publishing.service.gov.uk *.staging.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.tax.service.gov.uk hmrc-uk.digital.nuance.com gov.klick2contact.com www.signin.service.gov.uk lux.speedcurve.com".
```

The content security policy originally included `gov.klick2contact.com` in 7c1670bc1dd88955fed54147178e2c661afe2ca7 in January 2020.
However, we started referencing `hmpowebchat.klick2contact.com` in 1a5adccfd19435c3bceaeab402224775ecbae638 in March 2020.

I'm not sure why this has only started failing today, nor whether `gov.klick2contact.com` is still in use.
My assumption is that that is a legacy thing and we should only allow connections to `hmpowebchat.klick2contact.com` from now on.
If that assumption is wrong, it will be relatively simple to add `gov.klick2contact.com` back in.