### PR TITLE
Add Puma to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add Puma to dependencies ([#214](https://github.com/alphagov/govuk_app_config/pull/214)).
+
 # 4.0.1
 
 - Update Content Security Policy with new klick2contact.com subdomain ([#213](https://github.com/alphagov/govuk_app_config/pull/213)).

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
+  spec.add_dependency "puma", "~> 5.0"
   spec.add_dependency "sentry-rails", "~> 4.5.0"
   spec.add_dependency "sentry-ruby", "~> 4.5.0"
   spec.add_dependency "statsd-ruby", "~> 1.5.0"

--- a/lib/govuk_app_config/govuk_puma.rb
+++ b/lib/govuk_app_config/govuk_puma.rb
@@ -1,0 +1,37 @@
+module GovukPuma
+  def self.configure_rails(config)
+    config.port ENV.fetch("PORT", 3000)
+
+    config.environment ENV.fetch("RAILS_ENV", "development")
+
+    if ENV["GOVUK_APP_LOGROOT"]
+      config.stdout_redirect "#{ENV['GOVUK_APP_LOGROOT']}/app.out.log" "#{ENV['GOVUK_APP_LOGROOT']}/app.err.log"
+    end
+
+    # `worker_timeout` specifies how many seconds Puma will wait before terminating a worker.
+    timeout = ENV.fetch("RAILS_ENV", "development") == "development" ? 3600 : 15
+    config.worker_timeout timeout
+
+    # When changing the min/max threads for Puma, also consider changing ActiveRecord to match.
+    max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+    min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
+    config.threads min_threads_count, max_threads_count
+
+    # `workers` specifies the number of worker processes that Puma will fork.
+    # The overall concurrency limit is worker count * max threads per worker.
+    config.workers ENV.fetch("WEB_CONCURRENCY", 2)
+
+    # `preload_app!` tells Puma to load application code before forking worker processes.
+    # This reduces RAM wastage by making better use of copy-on-write.
+    config.preload_app!
+
+    config.before_fork do |_server|
+      next unless ENV["GOVUK_APP_ROOT"]
+
+      ENV["BUNDLE_GEMFILE"] = "#{ENV['GOVUK_APP_ROOT']}/Gemfile"
+    end
+
+    # Allow puma to be restarted by `rails restart` command.
+    config.plugin :tmp_restart
+  end
+end


### PR DESCRIPTION
This PR adds Puma to govuk_app_template's dependencies, along with a config file defining sensible defaults (and trying to keep inline with Unicorn to a large degree). Puma will be used as the default webserver when apps are replatformed to Kubernetes; this commit enables that work to progress using a single source of truth for configuration and following the same practice as we currently use for managing Unicorn.

[Trello card](https://trello.com/c/irrbEFMV/668)