### PR TITLE
Bump version to `4.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.1.0
 
 - Add Puma to dependencies ([#214](https://github.com/alphagov/govuk_app_config/pull/214)).
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.0.1".freeze
+  VERSION = "4.1.0".freeze
 end


### PR DESCRIPTION
Releases:

- Add Puma to dependencies ([#214](https://github.com/alphagov/govuk_app_config/pull/214))

Trello: https://trello.com/c/irrbEFMV