### PR TITLE
Remove Speedcurve's LUX from `connect-src` policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Remove Speedcurve's LUX from the connect-src policy ([#216](https://github.com/alphagov/govuk_app_config/pull/216)).
+
 # 4.2.0
 
 - Add pluralisation rules for Azerbaijani, Persian, Georgian, and Turkish. ([#219](https://github.com/alphagov/govuk_app_config/pull/219))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -78,13 +78,7 @@ module GovukContentSecurityPolicy
                        # Allow JSON call to klick2contact - HMPO web chat provider
                        "hmpowebchat.klick2contact.com",
                        # Allow connecting to Verify to check whether the user is logged in
-                       "www.signin.service.gov.uk",
-                       # Allow connection to Speedcurve's CDN for LUX - used for
-                       # real user metrics on GOV.UK. This loads using an image
-                       # (see image policy), but returns a JavaScript file -
-                       # which is why this has to be added to the `connect-src`
-                       # policy as well.
-                       "lux.speedcurve.com"
+                       "www.signin.service.gov.uk"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #


### PR DESCRIPTION
## What

Removes the domain the LUX uses for reporting real user metrics from the `connect-src` content security policy.

Reverts #206.

## Why

The domain was originally added because although an image was being used to report the metrics, the image was being served with a content type of `application/javascript`. This meant the loading of the image was being blocked, which prevented any metrics from being reported.

This rule can now be removed from the `connect-src` set of rules as the content type is now `image/webp`:


<img width="2672" alt="Screenshot 2021-11-10 at 11 11 46" src="https://user-images.githubusercontent.com/1732331/141103068-c9cdb08e-4a76-4ebf-80da-ce5842ef51a6.png">

and is allowed as the domain is in the `img-src` policy:

https://github.com/alphagov/govuk_app_config/blob/a6db8fce8bfaf588053ebb1fe55863043bcc7721/lib/govuk_app_config/govuk_content_security_policy.rb#L36-L38

