### PR TITLE
Add cache module for consistent cache behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.0
+
+- Added `GovukCache` for consistent cacheing.
+
 # 4.1.0
 
 - Add Puma to dependencies ([#214](https://github.com/alphagov/govuk_app_config/pull/214)).

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,5 +1,6 @@
 require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
+require "govuk_app_config/govuk_cache"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_healthcheck"
 require "govuk_app_config/govuk_i18n"

--- a/lib/govuk_app_config/govuk_cache.rb
+++ b/lib/govuk_app_config/govuk_cache.rb
@@ -1,0 +1,5 @@
+module GovukCache
+  # Expected to be used by Rails ActionController calls to expires_in.
+  # https://apidock.com/rails/ActionController/Base/expires_in
+  FRONTEND_EXPIRY_SECONDS = 300
+end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.1.0".freeze
+  VERSION = "4.2.0".freeze
 end

--- a/spec/lib/govuk_cache_spec.rb
+++ b/spec/lib/govuk_cache_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+require "govuk_app_config/govuk_cache"
+
+RSpec.describe GovukCache do
+  describe "FRONTEND_EXPIRY_SECONDS" do
+    it "returns 300 seconds" do
+      expect(described_class::FRONTEND_EXPIRY_SECONDS).to eq(300)
+    end
+  end
+end


### PR DESCRIPTION
This will enable frontend applications to set `GovukCache::FRONTEND_EXPIRY_SECONDS`, so that pages are consistently cached for 5 minutes by Fastly (our CDN) and our self-hosted Varnish instance.

At the moment we (generally) cache pages for 30 minutes. This requires us to run a fairly complex cache invalidation solution to keep content fresh which produces hard-to-debug errors when it breaks.

Rather than continue to maintain the cache invalidation logic, we will reduce the cache-control expiry from 30 minutes to 5 minutes, removing the need to expire the caches proactively (since they'll expire by themselves).

Related docs:
* https://docs.publishing.service.gov.uk/manual/purge-cache.html
* https://docs.publishing.service.gov.uk/apps/cache-clearing-service.html
* Recent cache invalidation logic [incident doc](https://docs.google.com/document/d/1yXGQxQv0IdeWxVegf8UHatnIrCTbd-ZslZB8AxN11QU/edit#heading=h.p99426yo0rbv) (GDS internal)