### PR TITLE
Fix loading gem due missing PrometheusExporter constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+# 4.4.1
+
+- Fix issue where GovukPrometheusExporter module prevented the gem to load due to missing constant "PrometheusExporter" ([#224](https://github.com/alphagov/govuk_app_config/pull/224)).
+- Lazy load the prometheus_exporter dependency for only apps that use GovukPrometheusExporter ([#224](https://github.com/alphagov/govuk_app_config/pull/224)).
+
 # 4.4.0
 
 - Add GovukPrometheusModule, to allow for export of prometheus metrics ([#223](https://github.com/alphagov/govuk_app_config/pull/223)).
+
 # 4.3.0
 
 - Remove Speedcurve's LUX from the connect-src policy ([#216](https://github.com/alphagov/govuk_app_config/pull/216)).

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -6,9 +6,9 @@ require "govuk_app_config/govuk_i18n"
 # This require is deprecated and should be removed on next major version bump
 # and should be required by applications directly.
 require "govuk_app_config/govuk_unicorn"
-require "govuk_app_config/govuk_prometheus_exporter"
 
 if defined?(Rails)
+  require "govuk_app_config/govuk_prometheus_exporter"
   require "govuk_app_config/govuk_logging"
   require "govuk_app_config/govuk_content_security_policy"
   require "govuk_app_config/railtie"

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,10 +1,10 @@
-require "prometheus_exporter"
-require "prometheus_exporter/server"
-require "prometheus_exporter/middleware"
-
 module GovukPrometheusExporter
   def self.configure
     unless Rails.env == "test"
+      require "prometheus_exporter"
+      require "prometheus_exporter/server"
+      require "prometheus_exporter/middleware"
+
       server = PrometheusExporter::Server::WebServer.new bind: "localhost", port: 9394
       server.start
 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,3 +1,4 @@
+require "prometheus_exporter"
 require "prometheus_exporter/server"
 require "prometheus_exporter/middleware"
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.4.0".freeze
+  VERSION = "4.4.1".freeze
 end


### PR DESCRIPTION
- Fix issue where GovukPrometheusExporter module prevented the gem to load due to missing constant. It was unable to find the top level module name "PrometheusExporter" and need to be explicity required.

- Lazy load the prometheus_exporter dependency for only apps that use GovukPrometheusExporter. This prevents the library from being required by apps the don't need it.

- Load GovukPrometheusExporter only for Rails apps, as it loads middleware into Rack and explicitly depends on Rails being present.