### PR TITLE
Add flag to only use prometheus exporter on kubernetes cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix prometheus_exporter to only be enabled when the GOVUK_PROMETHEUS_EXPORTER env var is set to "true" ([#231](https://github.com/alphagov/govuk_app_config/pull/231)).
+- Add Prometheus monitoring for EKS section to README.md ([#231](https://github.com/alphagov/govuk_app_config/pull/231)).
 - Fix govuk_error being incompatible with Ruby >= 3 ([#233](https://github.com/alphagov/govuk_app_config/pull/233))
 - Require Ruby 2.7 as the minimum supported Ruby version ([#233](https://github.com/alphagov/govuk_app_config/pull/233))
 - Require Sentry 5 and Unicorn 6 major versions ([#237](https://github.com/alphagov/govuk_app_config/pull/237))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Adds the basics of a GOV.UK application:
 - Statsd client for reporting stats
 - Rails logging
 - Content Security Policy generation for frontend apps
+- Prometheus monitoring for EKS
 
 ## Installation
 
@@ -165,6 +166,15 @@ GovukContentSecurityPolicy.configure
 ## i18n rules 
 
 Some frontend apps support languages that are not defined in the i18n gem. This provides them with our own custom rules for these languages.
+
+## Prometheus monitoring for EKS
+
+Create a `/config/initializers/prometheus.rb` file in the app and add the following
+
+```ruby
+require "govuk_app_config/govuk_prometheus_exporter"	
+GovukPrometheusExporter.configure	
+```
 
 ## License
 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,6 +1,6 @@
 module GovukPrometheusExporter
   def self.configure
-    unless Rails.env == "test"
+    unless Rails.env == "test" || (ENV["GOVUK_PROMETHEUS_EXPORTER"]) != "true"
       require "prometheus_exporter"
       require "prometheus_exporter/server"
       require "prometheus_exporter/middleware"


### PR DESCRIPTION
Enable prometheus_exporter on EKS only, extra latency and 500 errors caused on EC2 instances running unicorn, don't expect to see the same on EKS with puma 

([Collections 2712](https://github.com/alphagov/collections/pull/2712))Had to be reverted due to increased latency being seen on the controllers of the collections app running on EC2 instances.
![image](https://user-images.githubusercontent.com/62617250/160419242-127321e2-b87e-46bb-8a43-d5a15af9b9ed.png)
