### PR TITLE
Add lux.speedcurve.com to connect_src CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add lux.speedcurve.com to connect_src for GOV.UK Content Security Policy ([#232](https://github.com/alphagov/govuk_app_config/pull/232))
 - Fix prometheus_exporter to only be enabled when the GOVUK_PROMETHEUS_EXPORTER env var is set to "true" ([#231](https://github.com/alphagov/govuk_app_config/pull/231)).
 - Add Prometheus monitoring for EKS section to README.md ([#231](https://github.com/alphagov/govuk_app_config/pull/231)).
 - Fix govuk_error being incompatible with Ruby >= 3 ([#233](https://github.com/alphagov/govuk_app_config/pull/233))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -31,11 +31,10 @@ module GovukContentSecurityPolicy
                    :data, # Base64 encoded images
                    *GOVUK_DOMAINS,
                    *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
+                   # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
+                   "lux.speedcurve.com",
                    # Some content still links to an old domain we used to use
-                   "assets.digital.cabinet-office.gov.uk",
-                   # Allow images to be loaded for Speedcurve's LUX - used for
-                   # getting real user metrics on GOV.UK
-                   "lux.speedcurve.com"
+                   "assets.digital.cabinet-office.gov.uk"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     policy.script_src :self,
@@ -71,6 +70,8 @@ module GovukContentSecurityPolicy
     policy.connect_src :self,
                        *GOVUK_DOMAINS,
                        *GOOGLE_ANALYTICS_DOMAINS,
+                       # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
+                       "lux.speedcurve.com",
                        # Allow connecting to web chat from HMRC contact pages
                        "www.tax.service.gov.uk",
                        # Allow JSON call to Nuance - HMRC web chat provider


### PR DESCRIPTION
This commit implements the recommended Content Security Policy (CSP) for
SpeedCurve RUM (a.k.a. Lux.js) as per their documentation. We however
have not implemented their script source because we use a self hosted
version of RUM [2].

This adds connect_src as a mechanism to communicate with RUM, this is
needed because the previous method we used to record metrics, LUX.becaonMode,
has been removed from Speedcurve RUM as of version 300 [3] which used
images, whereas version 300 uses JS to send HTTP requests.

I'm not sure if there remains to be any value having an img_src entry
for lux.speedcurve.com as I'm not sure it is used beyond LUX.beaconMode,
however it is still referenced in their recommended CSP [1].

The motivation for making this change is that we are seeing intermittent
errors on the Smokey test suite, which presumably are occurring whenever
RUM gets used. Example error:

```
https://www.integration.publishing.service.gov.uk/?smokey_cachebust=0.40911524769922525 - [Report Only] Refused to connect to 'https://lux.speedcurve.com/lux/?v=300&id=47044334&sid=164914853971764200&uid=164914853971764200&l=Welcome%20to%20GOV.UK&NT=1649148539305fs0ds0de0cs0ce0qs1bs5be15ol11oi198os198oe213oc215ls215le215sr165fc165&LJS=&PS=ns7bs0is1051ss4bc2ic0ia0it3dd9nd567vh600vw785dh4717dw785ds11601ct4G_er0nt0dm4&CPU=s|0,n|0,d|0,x|0,i|165&fl=80&HN=www.integration.publishing.service.gov.uk&PN=%2F' because it violates the following Content Security Policy directive: "connect-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk [www.gov.uk](http://www.gov.uk/) *.dev.gov.uk [www.google-analytics.com](http://www.google-analytics.com/) ssl.google-analytics.com stats.g.doubleclick.net [www.googletagmanager.com](http://www.googletagmanager.com/) [www.tax.service.gov.uk](http://www.tax.service.gov.uk/) hmrc-uk.digital.nuance.com hmpowebchat.klick2contact.com omni.eckoh.uk [www.signin.service.gov.uk](http://www.signin.service.gov.uk/)".
```

[1]: https://support.speedcurve.com/docs/add-rum-to-your-csp
[2]: https://github.com/alphagov/govuk_publishing_components/blob/3674bf941cacbe97161f29ed63a349467d720eb2/docs/real-user-metrics.md
[3]: https://support.speedcurve.com/changelog/rum-update-luxjs-v300

This should resolve alphagov/govuk_publishing_components#2717.