### PR TITLE
Only require sentry-rails if Rails is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Prevent sentry-rails logger warnings when govuk_error is used with non-Rails apps ([#234](https://github.com/alphagov/govuk_app_config/pull/234))
+
 # 4.4.3
 
 - Update prometheus exporter server to 0.0.0.0 from localhost  ([#227](https://github.com/alphagov/govuk_app_config/pull/227)).

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -1,5 +1,5 @@
 require "sentry-ruby"
-require "sentry-rails"
+require "sentry-rails" if defined?(Rails)
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error/configuration"
 require "govuk_app_config/version"


### PR DESCRIPTION
Without this non Rails app will get a warning each time they initialise.

For example, Search API has:

```
W, [2022-03-10T09:45:26.609711 #11663] WARN -- sentry: ** [Sentry] sentry-rails can't detect Rails.logger. it may be caused by misplacement of the SDK initialization code
```