### PR TITLE
Some rubocop TLC

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Lint Ruby"
 task :lint do
-  sh "bundle exec rubocop --format clang"
+  sh "bundle exec rubocop"
 end
 
 task default: %i[spec lint]

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rspec-its", "~> 1.3"
-  spec.add_development_dependency "rubocop-govuk"
+  spec.add_development_dependency "rubocop-govuk", "4.3.0"
   spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
It's good to pin this to a particular version of rubocop-govuk,
otherwise we may have different results locally and in CI.

There doesn't seem to be any rationale for the `--format clang` argument
on rubocop so might as well remove it.