### PR TITLE
Upgrade Rails dev dependency to Rails 7

### DIFF
--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "rack-test", "~> 1.1"
-  spec.add_development_dependency "rails", "~> 6"
+  spec.add_development_dependency "rails", "~> 7"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rspec-its", "~> 1.3"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/testing/time_helpers"
 require "byebug"
 require "climate_control"


### PR DESCRIPTION
It's good to test against the current version of Rails. I don't think we
do enough with Rails testing that it is worth to test this with both
Rails 6 and Rails 7. I could be persuaded otherwise if problems occur.

This required an update for the tests as the base active_support
dependency now needs to be required before requiring any extensions.