### PR TITLE
Loosen and bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Require Sentry 5 and Unicorn 6 major versions ([#237](https://github.com/alphagov/govuk_app_config/pull/237))
 - Prevent sentry-rails logger warnings when govuk_error is used with non-Rails apps ([#234](https://github.com/alphagov/govuk_app_config/pull/234))
 
 # 4.4.3

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_dependency "logstasher", ">= 1.2.2", "< 2.2.0"
-  spec.add_dependency "prometheus_exporter", "~> 2.0.2"
+  spec.add_dependency "logstasher", "~> 2.1"
+  spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", "~> 5.0"
-  spec.add_dependency "sentry-rails", "~> 4.5.0"
-  spec.add_dependency "sentry-ruby", "~> 4.5.0"
-  spec.add_dependency "statsd-ruby", "~> 1.5.0"
-  spec.add_dependency "unicorn", ">= 5.4", "< 5.9"
+  spec.add_dependency "sentry-rails", "~> 4.5"
+  spec.add_dependency "sentry-ruby", "~> 4.5"
+  spec.add_dependency "statsd-ruby", "~> 1.5"
+  spec.add_dependency "unicorn", "~> 5.4"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "climate_control"

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "logstasher", "~> 2.1"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
-  spec.add_dependency "puma", "~> 5.0"
-  spec.add_dependency "sentry-rails", "~> 4.5"
-  spec.add_dependency "sentry-ruby", "~> 4.5"
+  spec.add_dependency "puma", "~> 5.6"
+  spec.add_dependency "sentry-rails", "~> 5.2"
+  spec.add_dependency "sentry-ruby", "~> 5.2"
   spec.add_dependency "statsd-ruby", "~> 1.5"
-  spec.add_dependency "unicorn", "~> 5.4"
+  spec.add_dependency "unicorn", "~> 6.1"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "climate_control"


### PR DESCRIPTION
We had set up the gem dependencies quite restrictive which meant apps were quite far behind in some cases (Sentry gems are up to 5.2). This updates the gems to their current versions with flexibility for the releases in the current major version. From looking at the respective change logs, both major version updates were very minor and shouldn't require us to make any app changes.

As this project is used as a way to provide dependencies to GOV.UK apps I've taken the approach that this gem pushes for apps to use newer versions rather than be very flexible in what it accepts - this is a deliberate decision to help keep GOV.UK apps on modern versions of dependencies. 

I've put examples of this into a couple of apps with e2e tests to check they pass all tests with these new versions:

Whitehall: https://github.com/alphagov/whitehall/tree/govuk_app_config-deps
Government Frontend: https://github.com/alphagov/government-frontend/tree/govuk_app_config-deps