### PR TITLE
Add warnings to integrate GovukError with sentry-sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add internal Sidekiq exception "Sidekiq::JobRetry::Skip" to excluded exceptions ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).
+
 # 4.5.0
 
 - Add lux.speedcurve.com to connect_src for GOV.UK Content Security Policy ([#232](https://github.com/alphagov/govuk_app_config/pull/232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.6.0
 
 - Add a warning for apps using GovukError with Sidekiq that don't have sentry-sidekiq installed ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).
 - Add internal Sidekiq exception "Sidekiq::JobRetry::Skip" to excluded exceptions ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add a warning for apps using GovukError with Sidekiq that don't have sentry-sidekiq installed ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).
 - Add internal Sidekiq exception "Sidekiq::JobRetry::Skip" to excluded exceptions ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).
 
 # 4.5.0

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logstasher", "~> 2.1"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", "~> 5.6"
-  spec.add_dependency "sentry-rails", "~> 5.2"
-  spec.add_dependency "sentry-ruby", "~> 5.2"
+  spec.add_dependency "sentry-rails", "~> 5.3"
+  spec.add_dependency "sentry-ruby", "~> 5.3"
   spec.add_dependency "statsd-ruby", "~> 1.5"
   spec.add_dependency "unicorn", "~> 6.1"
 

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -34,6 +34,10 @@ module GovukError
   def self.configure
     raise GovukError::AlreadyInitialised if is_configured?
 
+    if defined?(Sidekiq) && !defined?(Sentry::Sidekiq)
+      warn "Warning: GovukError is not configured to track Sidekiq errors, install the sidekiq-sentry gem to track them."
+    end
+
     Sentry.init do |sentry_config|
       config = Configuration.new(sentry_config)
       yield config if block_given?

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -53,6 +53,7 @@ module GovukError
         "Mongoid::Errors::DocumentNotFound",
         "Sinatra::NotFound",
         "Slimmer::IntermittentRetrievalError",
+        "Sidekiq::JobRetry::Skip",
       ]
 
       # This will exclude exceptions that are triggered by one of the ignored

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.5.0".freeze
+  VERSION = "4.6.0".freeze
 end

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe GovukError do
       expect { GovukError.configure { |_config| } }
         .to raise_exception(GovukError::AlreadyInitialised)
     end
+
+    it "raises a warning if Sidekiq exists but Sidekiq::Sentry does not" do
+      stub_const("Sidekiq", "Sidekiq")
+      allow(Sentry).to receive(:get_current_client).and_return(nil)
+
+      expect { GovukError.configure }
+        .to output(/Warning: GovukError is not configured to track Sidekiq errors/).to_stderr
+    end
   end
 
   describe ".is_configured?" do

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe GovukError do
 
   describe ".configure" do
     it "configures Sentry via the Configuration, and raises exception for subsequent calls" do
+      allow(Sentry).to receive(:get_current_client).and_return(nil)
       expect { |b| GovukError.configure(&b) }
         .to yield_with_args(instance_of(GovukError::Configuration))
 
+      allow(Sentry).to receive(:get_current_client).and_return(double("Sentry::Client"))
       expect { GovukError.configure { |_config| } }
         .to raise_exception(GovukError::AlreadyInitialised)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

This PR looks to address one of the things that has been problematic since the replacement of sentry-raven, how Sidekiq integrates with Sentry. As part of the introduction [sentry-sidekiq](https://docs.sentry.io/platforms/ruby/guides/sidekiq/) was created as a new gem for integrating with Sentry. In my recent experience of sentry alerts and GOV.UK apps, whether an app alerts to sentry from Sidekiq seems to be rather inconsistent. We're seeing some apps alert Sidekiq::JobRetry::Skip exceptions, others seem to alert nothing - it's a bit confusing but installing sidekiq-sentry seems to settle it down.

I don't think it's a good idea to add sentry-sidekiq as a dependency to this gem however as that would mean that all apps that use it would get Sidekiq and a number of other indirect dependencies, which seems both a bit of a pain and a source of confusion. Therefore I've added a warning to prompt apps that use Sidekiq to install sentry sidekiq.

Example:

```
➜  link-checker-api git:(app-config-local) ✗ rails c
Warning: GovukError is not configured to track Sidekiq errors, install the sidekiq-sentry gem to track them.
Loading development environment (Rails 7.0.2.3)
irb(main):001:0>
```

I've also added "Sidekiq::JobRetry::Skip" to the list of excluded exceptions since this is an internal exception [that sidekiq-sentry ignores](https://github.com/getsentry/sentry-ruby/blob/0fe8d27e4f84fda11475437a1cdd16f016efd904/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb#L7-L12) - however because of our custom configuration we seem to need to add this exception to our list manually.