### PR TITLE
Fix gem name in warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.6.1
+
+- Fixes warning message to refer to correct Sidekiq gem dependency name ([#243](https://github.com/alphagov/govuk_app_config/pull/243)).
+
 # 4.6.0
 
 - Add a warning for apps using GovukError with Sidekiq that don't have sentry-sidekiq installed ([#241](https://github.com/alphagov/govuk_app_config/pull/241)).

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -35,7 +35,7 @@ module GovukError
     raise GovukError::AlreadyInitialised if is_configured?
 
     if defined?(Sidekiq) && !defined?(Sentry::Sidekiq)
-      warn "Warning: GovukError is not configured to track Sidekiq errors, install the sidekiq-sentry gem to track them."
+      warn "Warning: GovukError is not configured to track Sidekiq errors, install the sentry-sidekiq gem to track them."
     end
 
     Sentry.init do |sentry_config|

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.6.0".freeze
+  VERSION = "4.6.1".freeze
 end


### PR DESCRIPTION
This was accidentally given the wrong name in the warning message.

[sidekiq-sentry does not exist](https://rubygems.org/search?query=sidekiq-sentry) - it should be [sentry-sidekiq](https://rubygems.org/gems/sentry-sidekiq).