### PR TITLE
Rewrite healthcheck guidance

### DIFF
--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -29,6 +29,8 @@ Built-in checks you can use include:
 
 - `GovukHealthcheck::RailsCache` - checks that the Rails cache store, such as Memcached, is acessible by writing and reading back a cache entry called "healthcheck-cache".
 
+- `GovukHealthcheck::Redis` - checks that the app can connect to Redis by writing and reading back a cache entry called "healthcheck-cache".
+
 - `GovukHealthcheck::Mongoid` - checks that the app has a connection to its Mongo database via Mongoid.
 
 - `GovukHealthcheck::SidekiqRedis` - checks that the app has a connection to Redis via Sidekiq.


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This makes a few improvements:

- Remove redundant content for built-in healthchecks that no longer exist.
- Reorganise content to be more succinct and action-oriented.
- Link to the healthcheck guidance in the dev doc to provide more context.

Reviewing by commit may be easier so you can follow the changes.