### PR TITLE
Use shared workflow to publish gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,33 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All matrix tests have passed 🚀"
-
-  release:
+     
+  publish:
     needs: test
-    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        rubygems: latest
-    - env:
-        GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
-        GEM_NAME: govuk_app_config
-      run: |
-        VERSION=$(ruby -e "puts eval(File.read('$GEM_NAME.gemspec')).version")
-        GEM_VERSION=$(gem list --exact --remote $GEM_NAME)
-
-        # Publish to RubyGems.org
-        if [ "${GEM_VERSION}" != "$GEM_NAME (${VERSION})" ]; then
-          gem build $GEM_NAME.gemspec
-          gem push "$GEM_NAME-${VERSION}.gem"
-        fi
-
-        # Create a release tag
-        if ! git ls-remote --tags --exit-code origin v${VERSION}; then
-          git tag v${VERSION}
-          git push --tags
-        fi
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+    secrets:
+      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This makes use of the shared workflow that has been added to
alphagov/govuk-infrastructure which allows publishing rubygems.