### PR TITLE
Add new GA domain to security policy

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -18,7 +18,8 @@ module GovukContentSecurityPolicy
   GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
                                 ssl.google-analytics.com
                                 stats.g.doubleclick.net
-                                www.googletagmanager.com].freeze
+                                www.googletagmanager.com
+                                www.region1.google-analytics.com].freeze
 
   GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
 


### PR DESCRIPTION
A new domain has caused our [smoke tests to fail](https://deploy.integration.publishing.service.gov.uk/job/Smokey/40512/console) This adds the new domain in which will hopefully fix the issue