### PR TITLE
Add region1.google-analytics.com to CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.6.3
+
+- Adds `region1.google-analytics.com` to the security policy for GA ([#250](https://github.com/alphagov/govuk_app_config/pull/250))
+
 # 4.6.2
 
 - Adds a new domain to the security policy for GA ([#248](https://https://github.com/alphagov/govuk_app_config/pull/248))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -19,7 +19,8 @@ module GovukContentSecurityPolicy
                                 ssl.google-analytics.com
                                 stats.g.doubleclick.net
                                 www.googletagmanager.com
-                                www.region1.google-analytics.com].freeze
+                                www.region1.google-analytics.com
+                                region1.google-analytics.com].freeze
 
   GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.6.2".freeze
+  VERSION = "4.6.3".freeze
 end


### PR DESCRIPTION
## What

We should update the [Content Security Policy (CSP)](https://github.com/alphagov/govuk_app_config/blob/4c7198b26acdb096be318c7aa343d46f02b7728d/lib/govuk_app_config/govuk_content_security_policy.rb) with `region1.google-analytics.com`.

## Why

The current CSP is throwing intermittent errors [on integration](https://www.integration.publishing.service.gov.uk/).

## Screenshots

| Before | After |
|---|---|
|<img width="1230" alt="Screenshot 2022-06-20 at 08 45 36" src="https://user-images.githubusercontent.com/44037625/174552010-c6a2e9c5-60ef-47e3-a99a-0691cdeaa36f.png">| |


[Trello](https://trello.com/c/o7LqB0tL/105-update-content-security-policy-csp)