### PR TITLE
WIP - allow CSP to be disabled entirely

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -97,6 +97,8 @@ module GovukContentSecurityPolicy
   end
 
   def self.configure
+    return if ENV.include?("GOVUK_CSP_DISABLE")
+
     Rails.application.config.content_security_policy_report_only = ENV.include?("GOVUK_CSP_REPORT_ONLY")
 
     Rails.application.config.content_security_policy(&method(:build_policy))

--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -50,5 +50,14 @@ RSpec.describe GovukContentSecurityPolicy do
           .to(false)
       end
     end
+
+    it "can be disabled by an ENV var" do
+      Rails.application.config.content_security_policy = nil
+
+      ClimateControl.modify(GOVUK_CSP_DISABLE: "yes") do
+        GovukContentSecurityPolicy.configure
+        expect(Rails.application.config.content_security_policy).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
At the moment we only have two settings for our CSP - fully on, or "report-only".

We don't actually have a working report-uri to point our CSP reports at.
It would be better to have no CSP at all in production than to have a broken report-only CSP.

It may be better to have an enum flag like:

GOVUK_CSP_MODE = {"on","report-only","disabled"}

... but that would be a little more work to implement.

This will require an additional change in GOV.UK puppet.