### PR TITLE
Add Sidekiq Prometheus instrumentation

### DIFF
--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -6,9 +6,9 @@ require "govuk_app_config/govuk_i18n"
 # This require is deprecated and should be removed on next major version bump
 # and should be required by applications directly.
 require "govuk_app_config/govuk_unicorn"
+require "govuk_app_config/govuk_prometheus_exporter"
 
 if defined?(Rails)
-  require "govuk_app_config/govuk_prometheus_exporter"
   require "govuk_app_config/govuk_logging"
   require "govuk_app_config/govuk_content_security_policy"
   require "govuk_app_config/railtie"

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,13 +1,35 @@
 module GovukPrometheusExporter
+  def self.should_configure
+    ENV["GOVUK_PROMETHEUS_EXPORTER"] == "true" && !(defined?(Rails) && Rails.env == "test")
+  end
+
   def self.configure
-    unless Rails.env == "test" || (ENV["GOVUK_PROMETHEUS_EXPORTER"]) != "true"
-      require "prometheus_exporter"
-      require "prometheus_exporter/server"
-      require "prometheus_exporter/middleware"
+    return unless should_configure
 
-      server = PrometheusExporter::Server::WebServer.new bind: "0.0.0.0", port: 9394
-      server.start
+    require "prometheus_exporter"
+    require "prometheus_exporter/server"
+    require "prometheus_exporter/middleware"
 
+    if defined?(Sidekiq)
+      Sidekiq.configure_server do |config|
+        require "prometheus_exporter/instrumentation"
+        config.server_middleware do |chain|
+          chain.add PrometheusExporter::Instrumentation::Sidekiq
+        end
+        config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+        config.on :startup do
+          PrometheusExporter::Instrumentation::Process.start(type: "sidekiq")
+          PrometheusExporter::Instrumentation::SidekiqProcess.start
+          PrometheusExporter::Instrumentation::SidekiqQueue.start
+          PrometheusExporter::Instrumentation::SidekiqStats.start
+        end
+      end
+    end
+
+    server = PrometheusExporter::Server::WebServer.new bind: "0.0.0.0", port: 9394
+    server.start
+
+    if defined?(Rails)
       Rails.application.middleware.unshift PrometheusExporter::Middleware
     end
   end


### PR DESCRIPTION
Add Sidekiq Prometheus instrumentation
If Sidekiq is present, add the Sidekiq Prometheus instrumentation.

Ref:
1. [trello card](https://trello.com/c/K8aUtwz4/974-graphs-for-sidekiq-queues-in-grafana)