### PR TITLE
Don't listen on Prometheus metrics port when running interactive.

### DIFF
--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,6 +1,11 @@
 module GovukPrometheusExporter
   def self.should_configure
-    ENV["GOVUK_PROMETHEUS_EXPORTER"] == "true" && !(defined?(Rails) && Rails.env == "test")
+    if File.basename($PROGRAM_NAME) == "rake" ||
+        defined?(Rails) && (Rails.const_defined?("Console") || Rails.env == "test")
+      false
+    else
+      ENV["GOVUK_PROMETHEUS_EXPORTER"] == "true"
+    end
   end
 
   def self.configure

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.7.0".freeze
+  VERSION = "4.7.1".freeze
 end


### PR DESCRIPTION
We don't want to initialise the Prometheus exporter when:
 - running the Rails console
 - running Rake tasks

Otherwise we end up with annoying port clashes and the user has to faff with disabling GOVUK_PROMETHEUS_EXPORTER in the environment just to do something simple like running a rake task or opening a console.

#### Testing

Built and deployed Signon using govuk_app_config from this branch and verified that `rails c` and `/metrics` both work without workarounds.

* Changed signon's `Gemfile`: `gem "govuk_app_config"` -> `gem "govuk_app_config", github: "alphagov/govuk_app_config", branch: "sengi/prometheus-port-clashes"`, run `bundle update govuk_app_config` and pushed those changes to a throwaway branch.
* Built and deployed signon to the integration cluster from the throwaway branch by running the `Deploy` GitHub Action.
* Checked that we're definitely running the new version.
* Verified that rails console now works without workarounds: `k exec -it deploy/signon -c app -- bundle exec rails c`
* Verified that we're still serving Prometheus metrics: `k exec -it deploy/signon -c app -- curl localhost:9394/metrics`
* Put integration back how we found it (ran the `automatic_deploys_enabled` GH Action to redeploy integration signon from the default branch and re-enabled automatic deploys).