### PR TITLE
Enable EKS environment names for Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Enables Sentry environment names for EKS versions of integration, staging and production.([#260](https://github.com/alphagov/govuk_app_config/pull/260))
+
 # 4.7.1
 
 - Fix the ability to open the Rails console (`bundle exec rails c`) when running inside a container ([#257](https://github.com/alphagov/govuk_app_config/pull/257)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.8.0
 
 - Enables Sentry environment names for EKS versions of integration, staging and production.([#260](https://github.com/alphagov/govuk_app_config/pull/260))
 

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -19,8 +19,11 @@ module GovukError
       # don't capture the error.
       self.enabled_environments = %w[
         integration-blue-aws
+        integration-eks
         staging
+        staging-eks
         production
+        production-eks
       ]
 
       self.excluded_exceptions = [

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.7.1".freeze
+  VERSION = "4.8.0".freeze
 end


### PR DESCRIPTION
This adds environment names for EKS versions of integration, staging and production.