### PR TITLE
Add GovukProxy::StaticProxy for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add GovukProxy::StaticProxy to forward Static asset requests by setting `GOVUK_PROXY_STATIC_ENABLED=true`.([#261](https://github.com/alphagov/govuk_app_config/pull/261))
+
 # 4.8.0
 
 - Enables Sentry environment names for EKS versions of integration, staging and production.([#260](https://github.com/alphagov/govuk_app_config/pull/260))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.9.0
 
 - Add GovukProxy::StaticProxy to forward Static asset requests by setting `GOVUK_PROXY_STATIC_ENABLED=true`.([#261](https://github.com/alphagov/govuk_app_config/pull/261))
 

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", "~> 2.1"
+  spec.add_dependency "plek", "~> 4"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", "~> 5.6"
   spec.add_dependency "rack-proxy", "~> 0.7"

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logstasher", "~> 2.1"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", "~> 5.6"
+  spec.add_dependency "rack-proxy", "~> 0.7"
   spec.add_dependency "sentry-rails", "~> 5.3"
   spec.add_dependency "sentry-ruby", "~> 5.3"
   spec.add_dependency "statsd-ruby", "~> 1.5"

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,6 +1,7 @@
 require "govuk_app_config/version"
 require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
+require "govuk_app_config/govuk_proxy/static_proxy"
 require "govuk_app_config/govuk_healthcheck"
 require "govuk_app_config/govuk_i18n"
 # This require is deprecated and should be removed on next major version bump

--- a/lib/govuk_app_config/govuk_proxy/static_proxy.rb
+++ b/lib/govuk_app_config/govuk_proxy/static_proxy.rb
@@ -1,0 +1,19 @@
+require "rack-proxy"
+
+module GovukProxy
+  class StaticProxy < Rack::Proxy
+    def perform_request(env)
+      request = Rack::Request.new(env)
+
+      # use rack proxy to forward any requests for /assets/static/*
+      # this regex needs to match the path set for `Rails.application.config.assets.prefix` in Static
+      # https://github.com/alphagov/static/blob/main/config/initializers/assets.rb
+      if request.path =~ %r{^/assets/static/}
+        env["HTTP_HOST"] = @backend.host
+        super(env)
+      else
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -1,5 +1,14 @@
+require "plek"
+
 module GovukAppConfig
   class Railtie < Rails::Railtie
+    initializer "govuk_app_config.configure_govuk_proxy" do |app|
+      if ENV["GOVUK_PROXY_STATIC_ENABLED"] == "true"
+        static_url = Plek.new.find("static")
+        app.middleware.use GovukProxy::StaticProxy, backend: static_url
+      end
+    end
+
     config.before_initialize do
       GovukLogging.configure if Rails.env.production?
     end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.8.0".freeze
+  VERSION = "4.9.0".freeze
 end

--- a/spec/lib/govuk_proxy/static_proxy_spec.rb
+++ b/spec/lib/govuk_proxy/static_proxy_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "govuk_app_config/govuk_proxy/static_proxy"
+require "rack/mock"
+
+RSpec.describe GovukProxy::StaticProxy do
+  def test_request(path, proxied)
+    dest_host = (proxied ? static_domain : app_domain)
+
+    stub_request(:get, "https://#{dest_host}#{path}")
+        .with(headers: { "Host" => dest_host })
+        .to_return(status: 200, body: "", headers: {})
+
+    env = Rack::MockRequest.env_for("http://#{app_domain}#{path}")
+    status, _headers, _response = proxy.call(env)
+    expect(status.to_i).to eq(200)
+  end
+
+  # dummy app to validate success
+  let(:app) { ->(_env) { [200, {}, "success"] } }
+  let(:app_domain) { "app.domain" }
+  let(:static_domain) { "static.domain" }
+
+  let(:proxy) { GovukProxy::StaticProxy.new(app, backend: "https://static.domain", streaming: false) }
+
+  it "redirects the request if path begins with /asset/static" do
+    test_request("/assets/static/a.css", true)
+  end
+
+  it "ignores requests not with path prefix /asset/static" do
+    test_request("/assets/app/a.css", false)
+  end
+
+  it "ignores requests where /asset/static isn't a prefix" do
+    test_request("/another/prefix/assets/static/a.css", false)
+  end
+
+  it "ignores requests with no path" do
+    test_request("/", false)
+  end
+end


### PR DESCRIPTION
This class can be loaded as Rack middleware and will proxy any requests with the path prefix of `/assets/static` to backend specified. This is useful as it enables Static to use relative paths and the dependent  frontend application can forward those requests. This allows us to switch Static to use relative path and allow us to have development environment and not run Static locally (i.e. forward request to production version of Static).

Rails can be made to initialise the proxy middleware by setting the `GOVUK_PROXY_STATIC_ENABLED=true` env var. 