### PR TITLE
Avoid INFO logspew from the Sentry gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.10.0
+
+- Reduce log level for the Sentry gem from `INFO` to `WARN` to avoid polluting logs with uninformative messages. This only affects log messages from the Sentry gem itself, which go to `stdout`.
+
 # 4.9.0
 
 - Add GovukProxy::StaticProxy to forward Static asset requests by setting `GOVUK_PROXY_STATIC_ENABLED=true`.([#261](https://github.com/alphagov/govuk_app_config/pull/261))

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -40,6 +40,8 @@ module GovukError
 
     Sentry.init do |sentry_config|
       config = Configuration.new(sentry_config)
+      # Avoid "Sending envelope with items ... to Sentry" logspew on stdout.
+      config.logger.level = Sentry::Logger::WARN
       yield config if block_given?
     end
   end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.9.0".freeze
+  VERSION = "4.10.0".freeze
 end

--- a/spec/lib/govuk_error_spec.rb
+++ b/spec/lib/govuk_error_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GovukError do
 
     it "sends the version along with the request" do
       GovukError.notify(StandardError.new, parameters: "Something")
-      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^[0-9]\.[0-9]\.[0-9](?:\.pre\.[0-9]+)?$/ }))
+      expect(Sentry).to have_received(:capture_exception).with(StandardError.new, hash_including(tags: { govuk_app_config_version: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\.pre\.[0-9]+)?$/ }))
     end
   end
 


### PR DESCRIPTION
The Sentry gem spams stdout with INFO logs like this by default, which is particularly annoying when troubleshooting. We don't need info-level logs from the Sentry integration itself.

    [Transport] Sending envelope with items [sessions]  to Sentry

This change doesn't affect the logging of events to Sentry, only the logging of messages from the Sentry gem itself. We're therefore only interested in log messages which might indicate that something is wrong, not log messages that simply indicate that something expected is happening - hence WARN is the appropriate level here.

See [Sentry Ruby config docs](https://docs.sentry.io/platforms/ruby/configuration/options/) under `logger`.