### PR TITLE
Fix an ownership bug when configuring the Sentry logger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.10.1
+
+- Fix an object ownership/sharing bug where the Rails log level was erroneously being set to `WARN` when initialising Sentry.
+
 # 4.10.0
 
 - Reduce log level for the Sentry gem from `INFO` to `WARN` to avoid polluting logs with uninformative messages. This only affects log messages from the Sentry gem itself, which go to `stdout`.

--- a/lib/govuk_app_config/govuk_error.rb
+++ b/lib/govuk_app_config/govuk_error.rb
@@ -40,8 +40,6 @@ module GovukError
 
     Sentry.init do |sentry_config|
       config = Configuration.new(sentry_config)
-      # Avoid "Sending envelope with items ... to Sentry" logspew on stdout.
-      config.logger.level = Sentry::Logger::WARN
       yield config if block_given?
     end
   end

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -74,6 +74,10 @@ module GovukError
         "GdsApi::ContentStore::ItemNotFound",
       ]
 
+      # Avoid "Sending envelope with items ... to Sentry" logspew, since we
+      # don't use Sentry's automatic session tracking.
+      self.auto_session_tracking = false
+
       @before_send_callbacks = [
         ignore_excluded_exceptions_in_data_sync,
         increment_govuk_statsd_counters,

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.10.0".freeze
+  VERSION = "4.10.1".freeze
 end


### PR DESCRIPTION
Sentry's default logger turns out to be a reference to `Rails.logger` by default, despite the [sentry-rails docs] saying that it defaults to an instance of `Sentry::Logger`. So I was unwittingly mutating `Rails.logger` through a shared reference. Oops.

Kudos to super sharp-eyed @kevindew for catching this!

Instead of trying to set the log level for the Sentry gem, just disable the "auto session tracking feature" that generates the spammy log messages, since it turns out we don't use that feature. 

Fixes a bug introduced in #263.

[sentry-rails docs]: https://docs.sentry.io/platforms/ruby/guides/rails/configuration/options/