### PR TITLE
Add plurals dropped from rails-i18n in 7.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add I18n plural rules for Welsh (cy), Maltese (mt) and Chinese (zh) since Rails-I18n has [dropped support](https://github.com/svenfuchs/rails-i18n/pull/1017) for them in 7.0.6 ([#266](https://github.com/alphagov/govuk_app_config/pull/266))
+
 # 4.10.1
 
 - Fix an object ownership/sharing bug where the Rails log level was erroneously being set to `WARN` when initialising Sentry.

--- a/lib/govuk_app_config/govuk_i18n.rb
+++ b/lib/govuk_app_config/govuk_i18n.rb
@@ -3,6 +3,19 @@ module GovukI18n
     {
       # Azerbaijani
       az: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Welsh
+      cy: { i18n: { plural: { keys: %i[zero one two few many other],
+                              rule:
+                                lambda do |n|
+                                  case n
+                                  when 0 then :zero
+                                  when 1 then :one
+                                  when 2 then :two
+                                  when 3 then :few
+                                  when 6 then :many
+                                  else :other
+                                  end
+                                end } } },
       # Dari - this isn't an iso code. Probably should be 'prs' as per ISO 639-3.
       dr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
       # Latin America and Caribbean Spanish
@@ -31,12 +44,31 @@ module GovukI18n
       kk: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
       # Punjabi Shahmukhi
       "pa-pk": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Maltese
+      mt: { i18n: { plural: { keys: %i[one few many other],
+                              rule:
+                                lambda do |n|
+                                  n ||= 0
+                                  mod100 = n % 100
+
+                                  if n == 1
+                                    :one
+                                  elsif n.zero? || (2..10).to_a.include?(mod100)
+                                    :few
+                                  elsif (11..19).to_a.include?(mod100)
+                                    :many
+                                  else
+                                    :other
+                                  end
+                                end } } },
       # Sinhalese
       si: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
       # Turkish
       tr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
       # Uzbek
       uz: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+      # Chinese
+      zh: { i18n: { plural: { keys: %i[other], rule: ->(_) { :other } } } },
       # Chinese Hong Kong
       "zh-hk" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
       # Chinese Taiwan


### PR DESCRIPTION
The 7.0.6 release of rails-i18n dropped support for a number of plurals [1] and this causes our apps that make use of these languages to error and thus be unable to update to rails-i18n 7.0.6 (example: https://github.com/alphagov/whitehall/pull/7042)

This commit ports over these rules from rails-i18n to maintain the behaviour.

There is also something of a duplicate of this file in [rails_translation_manager](https://github.com/alphagov/rails_translation_manager/blob/main/config/locales/plurals.rb) that may also need an update. I'm unsure of the status of that file though as it is already out-of-sync with this one and I think this one takes priority.

[1]: https://github.com/svenfuchs/rails-i18n/pull/1017