### PR TITLE
Update to support Plek 5 and release 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Update Plek support to allow version 5
 - Add I18n plural rules for Welsh (cy), Maltese (mt) and Chinese (zh) since Rails-I18n has [dropped support](https://github.com/svenfuchs/rails-i18n/pull/1017) for them in 7.0.6 ([#266](https://github.com/alphagov/govuk_app_config/pull/266))
 
 # 4.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.11.0
 
 - Update Plek support to allow version 5
 - Add I18n plural rules for Welsh (cy), Maltese (mt) and Chinese (zh) since Rails-I18n has [dropped support](https://github.com/svenfuchs/rails-i18n/pull/1017) for them in 7.0.6 ([#266](https://github.com/alphagov/govuk_app_config/pull/266))

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", "~> 2.1"
-  spec.add_dependency "plek", "~> 4"
+  spec.add_dependency "plek", ">= 4", "< 6"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", ">= 5.6", "< 7.0"
   spec.add_dependency "rack-proxy", "~> 0.7"

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -4,8 +4,7 @@ module GovukAppConfig
   class Railtie < Rails::Railtie
     initializer "govuk_app_config.configure_govuk_proxy" do |app|
       if ENV["GOVUK_PROXY_STATIC_ENABLED"] == "true"
-        static_url = Plek.new.find("static")
-        app.middleware.use GovukProxy::StaticProxy, backend: static_url
+        app.middleware.use GovukProxy::StaticProxy, backend: Plek.find("static")
       end
     end
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.10.1".freeze
+  VERSION = "4.11.0".freeze
 end


### PR DESCRIPTION
This updates this gem to support Plek 5 (with a minor syntax tweak on existing Plek usage) and updates the gem version.

The release also includes: https://github.com/alphagov/govuk_app_config/pull/266