### PR TITLE
Clean up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: aws-xray-sdk
-    versions:
-    - "> 0.10.0"


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This makes the dependabot config for this gem consistent with other GOV.UK gems, monitoring bundler and github-actions