### PR TITLE
Spring clean of the Content Security Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* CSP only allows scripts, styles and fonts from self which reflects GOV.UK production behaviour
 * Set the default CSP behaviour to be allow communication only to self
 * Remove webchat scripts from the CSP, these are now handled in [government-frontend](https://github.com/alphagov/government-frontend/pull/2643)
 * Remove `www.signin.service.gov.uk` from the CSP as it is no-longer used in GOV.UK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove webchat scripts from the CSP, these are now handled in [government-frontend](https://github.com/alphagov/government-frontend/pull/2643)
 * Remove `www.signin.service.gov.uk` from the CSP as it is no-longer used in GOV.UK
 * Disallow data fonts in the global Content Security policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove `www.signin.service.gov.uk` from the CSP as it is no-longer used in GOV.UK
 * Disallow data fonts in the global Content Security policy
 
 # 4.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Allow `https://img.youtube.com` as a CSP image source
 * CSP only allows scripts, styles and fonts from self which reflects GOV.UK production behaviour
 * Set the default CSP behaviour to be allow communication only to self
 * Remove webchat scripts from the CSP, these are now handled in [government-frontend](https://github.com/alphagov/government-frontend/pull/2643)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Set the default CSP behaviour to be allow communication only to self
 * Remove webchat scripts from the CSP, these are now handled in [government-frontend](https://github.com/alphagov/government-frontend/pull/2643)
 * Remove `www.signin.service.gov.uk` from the CSP as it is no-longer used in GOV.UK
 * Disallow data fonts in the global Content Security policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Disallow data fonts in the global Content Security policy
+
 # 4.11.1
 
 - Remove govuk_i18n plural rules file

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -43,8 +43,6 @@ module GovukContentSecurityPolicy
                       *GOVUK_DOMAINS,
                       *GOOGLE_ANALYTICS_DOMAINS,
                       *GOOGLE_STATIC_DOMAINS,
-                      # Allow JSONP call to Verify to check whether the user is logged in
-                      "www.signin.service.gov.uk",
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
                       "*.ytimg.com",
                       "www.youtube.com",
@@ -80,9 +78,7 @@ module GovukContentSecurityPolicy
                        # Allow JSON call to klick2contact - HMPO web chat provider
                        "hmpowebchat.klick2contact.com",
                        # Allow JSON call to Eckoh - HMPO web chat provider
-                       "omni.eckoh.uk",
-                       # Allow connecting to Verify to check whether the user is logged in
-                       "www.signin.service.gov.uk"
+                       "omni.eckoh.uk"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -40,7 +40,6 @@ module GovukContentSecurityPolicy
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     policy.script_src :self,
-                      *GOVUK_DOMAINS,
                       *GOOGLE_ANALYTICS_DOMAINS,
                       *GOOGLE_STATIC_DOMAINS,
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
@@ -54,14 +53,13 @@ module GovukContentSecurityPolicy
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
     policy.style_src :self,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_STATIC_DOMAINS,
                      # We use the `style=""` attribute on some HTML elements
                      :unsafe_inline
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
     # Note: we purposely don't include data here because it produces a security risk.
-    policy.font_src :self, *GOVUK_DOMAINS
+    policy.font_src :self
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
     policy.connect_src :self,

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -64,9 +64,8 @@ module GovukContentSecurityPolicy
                      :unsafe_inline
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
-    policy.font_src :self,
-                    *GOVUK_DOMAINS,
-                    :data # Used by some legacy fonts
+    # Note: we purposely don't include data here because it produces a security risk.
+    policy.font_src :self, *GOVUK_DOMAINS
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
     policy.connect_src :self,

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -1,12 +1,12 @@
 module GovukContentSecurityPolicy
   # Generate a Content Security Policy (CSP) directive.
   #
-  # See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more CSP info.
+  # Before making any changes please read our documentation: https://docs.publishing.service.gov.uk/manual/content-security-policy.html
   #
-  # The resulting policy should be checked with:
+  # If you are making a change here you should consider 2 basic rules of thumb:
   #
-  # - https://csp-evaluator.withgoogle.com
-  # - https://cspvalidator.org
+  # 1. Are you creating a XSS risk? Adding unsafe-* declarations, allowing data: URLs or being overly permissive (e.g. https) risks these
+  # 2. Is this change needed globally, if it's just one or two apps the change should be applied in them directly.
 
   GOVUK_DOMAINS = [
     "*.publishing.service.gov.uk",
@@ -30,7 +30,11 @@ module GovukContentSecurityPolicy
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
     policy.img_src :self,
-                   :data, # Base64 encoded images
+                   # This allows Base64 encoded images, but is a security
+                   # risk as it can embed third party resources.
+                   # As of December 2022, we intend to remove this prior
+                   # to making the CSP live.
+                   :data,
                    *GOVUK_DOMAINS,
                    *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
                    # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
@@ -46,15 +50,18 @@ module GovukContentSecurityPolicy
                       "*.ytimg.com",
                       "www.youtube.com",
                       "www.youtube-nocookie.com",
-                      # Allow all inline scripts until we can conclusively
-                      # document all the inline scripts we use,
-                      # and there's a better way to filter out junk reports
+                      # This allows inline scripts and thus is a XSS risk.
+                      # As of December 2022, we intend to work towards removing
+                      # this from apps that don't use jQuery 1.12 (which needs
+                      # this) once we've set up nonces.
                       :unsafe_inline
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
     policy.style_src :self,
                      *GOOGLE_STATIC_DOMAINS,
-                     # We use the `style=""` attribute on some HTML elements
+                     # This allows style="" attributes and style elements.
+                     # As of December 2022, we intend to remove this prior
+                     # to making the CSP live due to the security risks it has.
                      :unsafe_inline
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -89,6 +89,14 @@ module GovukContentSecurityPolicy
   def self.configure
     Rails.application.config.content_security_policy_report_only = ENV.include?("GOVUK_CSP_REPORT_ONLY")
 
-    Rails.application.config.content_security_policy(&method(:build_policy))
+    policy = Rails.application.config.content_security_policy(&method(:build_policy))
+
+    # # allow apps to customise the CSP by passing a block e.g:
+    # GovukContentSecuirtyPolicy.configure do |policy|
+    #   policy.image_src(*policy.image_src, "https://i.ytimg.com")
+    # end
+    yield(policy) if block_given?
+
+    policy
   end
 end

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -26,7 +26,7 @@ module GovukContentSecurityPolicy
 
   def self.build_policy(policy)
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
-    policy.default_src :https, :self, *GOVUK_DOMAINS
+    policy.default_src :self
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
     policy.img_src :self,

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -40,7 +40,9 @@ module GovukContentSecurityPolicy
                    # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
                    "lux.speedcurve.com",
                    # Some content still links to an old domain we used to use
-                   "assets.digital.cabinet-office.gov.uk"
+                   "assets.digital.cabinet-office.gov.uk",
+                   # Allow YouTube thumbnails
+                   "https://img.youtube.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     policy.script_src :self,

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -47,8 +47,6 @@ module GovukContentSecurityPolicy
                       "*.ytimg.com",
                       "www.youtube.com",
                       "www.youtube-nocookie.com",
-                      # Allow JSONP call to Nuance - HMRC web chat provider
-                      "hmrc-uk.digital.nuance.com",
                       # Allow all inline scripts until we can conclusively
                       # document all the inline scripts we use,
                       # and there's a better way to filter out junk reports
@@ -70,15 +68,7 @@ module GovukContentSecurityPolicy
                        *GOVUK_DOMAINS,
                        *GOOGLE_ANALYTICS_DOMAINS,
                        # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
-                       "lux.speedcurve.com",
-                       # Allow connecting to web chat from HMRC contact pages
-                       "www.tax.service.gov.uk",
-                       # Allow JSON call to Nuance - HMRC web chat provider
-                       "hmrc-uk.digital.nuance.com",
-                       # Allow JSON call to klick2contact - HMPO web chat provider
-                       "hmpowebchat.klick2contact.com",
-                       # Allow JSON call to Eckoh - HMPO web chat provider
-                       "omni.eckoh.uk"
+                       "lux.speedcurve.com"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #

--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -50,5 +50,10 @@ RSpec.describe GovukContentSecurityPolicy do
           .to(false)
       end
     end
+
+    it "yields an instance of the policy if a block is provided" do
+      expect { |b| GovukContentSecurityPolicy.configure(&b) }
+        .to yield_with_args(an_instance_of(ActionDispatch::ContentSecurityPolicy))
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This updates the Content Security Policy in a number of ways:

- It removes legacy declarations: data fonts, various webchat hosts and a verify script
- It simplifies the base CSP rule to be only the current host, whereas previously it was any https script, which seemed rather broad.
- It drops setting a variety of asset hosts, this is no longer needed in production as load all assets with relative paths
- It updates documentation on usage and current intentions.
- It adds https://img.youtube.com as an image-src to support the [YouTube card component](https://github.com/alphagov/govuk_publishing_components/pull/3156)