### PR TITLE
Flush log writes to stdout immediately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.13.0
+
+- Flush log writes to stdout immediately so that structured (JSON) logs are not lost on crash or delayed indefinitely.
+
 # 4.12.0
 
 * Allow `https://img.youtube.com` as a CSP image source

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.12.0".freeze
+  VERSION = "4.13.0".freeze
 end


### PR DESCRIPTION
Log writes to stdout were being buffered such that log entries could be delayed indefinitely, which frustrates troubleshooting in production and can lead to log messages being lost on crash.

Explicitly enable [IO.sync] on stdout/stderr to have Ruby flush writes immediately to the underlying system.

stderr was actually already unbuffered, but since we need to set stdout I think it'd be confusing not to specify both.

While we're there, remove a couple of redundant comments and tidy up the remaining ones.

[IO.sync]: https://ruby-doc.org/2.7.7/IO.html#method-i-sync-3D                               

```
ruby <<'EOF'
puts "$stdout.sync=#{$stdout.sync}"
puts "$stderr.sync=#{$stderr.sync}"
puts

$real_stdout = $stdout.clone
$stdout.reopen($stderr)
puts "$stdout.sync=#{$stdout.sync}"
puts "$stderr.sync=#{$stderr.sync}"
puts "$real_stdout.sync=#{$real_stdout.sync}"
puts

$real_stdout.sync = true
$stdout.sync = true
puts "$stdout.sync=#{$stdout.sync}"
puts "$stderr.sync=#{$stderr.sync}"
puts "$real_stdout.sync=#{$real_stdout.sync}"
EOF
```

```
$stdout.sync=false
$stderr.sync=true

$stdout.sync=true
$stderr.sync=true
$real_stdout.sync=false

$stdout.sync=true
$stderr.sync=true
$real_stdout.sync=true
```