### PR TITLE
Configure Content Security Policy to remove risky allowed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Content Security Policy forbids unsafe-inline script-src and data: image-src. It provides a nonce generator. Apps that can't support this will need to amend their CSP configuration in an initializer, see [example](https://github.com/alphagov/signon/commit/ddcf31f5c30b8fd334e4aea74986b24bf2b0e9be) in signon. Any apps that still use jQuery 1.x will need unsafe-inline for Firefox compatibility.
+
 # 4.13.0
 
 * Flush log writes to stdout immediately so that structured (JSON) logs are not lost on crash or delayed indefinitely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Forbid base elements in the Content Security Policy
 * BREAKING: Content Security Policy forbids unsafe-inline script-src and data: image-src. It provides a nonce generator. Apps that can't support this will need to amend their CSP configuration in an initializer, see [example](https://github.com/alphagov/signon/commit/ddcf31f5c30b8fd334e4aea74986b24bf2b0e9be) in signon. Any apps that still use jQuery 1.x will need unsafe-inline for Firefox compatibility.
 
 # 4.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 5.0.0
 
 * Forbid base elements in the Content Security Policy
 * BREAKING: Content Security Policy forbids unsafe-inline script-src and data: image-src. It provides a nonce generator. Apps that can't support this will need to amend their CSP configuration in an initializer, see [example](https://github.com/alphagov/signon/commit/ddcf31f5c30b8fd334e4aea74986b24bf2b0e9be) in signon. Any apps that still use jQuery 1.x will need unsafe-inline for Firefox compatibility.

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -29,12 +29,8 @@ module GovukContentSecurityPolicy
     policy.default_src :self
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
+    # Note: we purposely don't include `data:` here because it produces a security risk.
     policy.img_src :self,
-                   # This allows Base64 encoded images, but is a security
-                   # risk as it can embed third party resources.
-                   # As of December 2022, we intend to remove this prior
-                   # to making the CSP live.
-                   :data,
                    *GOVUK_DOMAINS,
                    *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
                    # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
@@ -45,25 +41,28 @@ module GovukContentSecurityPolicy
                    "https://img.youtube.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+    # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
+    # they are security risks, if you need them for a legacy app please only apply them at
+    # an app level.
     policy.script_src :self,
                       *GOOGLE_ANALYTICS_DOMAINS,
                       *GOOGLE_STATIC_DOMAINS,
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
                       "*.ytimg.com",
                       "www.youtube.com",
-                      "www.youtube-nocookie.com",
-                      # This allows inline scripts and thus is a XSS risk.
-                      # As of December 2022, we intend to work towards removing
-                      # this from apps that don't use jQuery 1.12 (which needs
-                      # this) once we've set up nonces.
-                      :unsafe_inline
+                      "www.youtube-nocookie.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
+    # Note: we purposely don't include `data:` or `unsafe-eval` because
+    # they are security risks, if you need them for a legacy app please only apply them at
+    # an app level.
     policy.style_src :self,
                      *GOOGLE_STATIC_DOMAINS,
-                     # This allows style="" attributes and style elements.
-                     # As of December 2022, we intend to remove this prior
-                     # to making the CSP live due to the security risks it has.
+                     # This allows `style=""` attributes and `<style>` elements.
+                     # As of January 2023 our intentions to remove this were scuppered
+                     # by Govspeak [1] using inline styles on tables. Until that
+                     # is resolved we'll keep unsafe_inline
+                     # [1]: https://github.com/alphagov/govspeak/blob/5642fcc4231f215d1c58ad7feb30ca42fb8cfb91/lib/govspeak/html_sanitizer.rb#L72-L73
                      :unsafe_inline
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
@@ -90,6 +89,20 @@ module GovukContentSecurityPolicy
 
   def self.configure
     Rails.application.config.content_security_policy_report_only = ENV.include?("GOVUK_CSP_REPORT_ONLY")
+
+    # Sets a nonce per request that can be set on script-src and style-src
+    # directives depending on the value of Rails.application.config.content_security_policy_nonce_directives
+    #
+    # Note: if an application needs to set unsafe-inline they will need to
+    # unset this generator (by setting this config option to nil in their application)
+    Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+    # This only applies the nonce generator to the script-src directive. We need this to
+    # use unsafe-inline for style-src as a nonce will override it.
+    #
+    # When we want to apply it to style-src we can remove this line as the Rails default
+    # is for both script-src and style-src
+    Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
     policy = Rails.application.config.content_security_policy(&method(:build_policy))
 

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -28,6 +28,9 @@ module GovukContentSecurityPolicy
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
     policy.default_src :self
 
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri
+    policy.base_uri :none
+
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
     # Note: we purposely don't include `data:` here because it produces a security risk.
     policy.img_src :self,

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "4.13.0".freeze
+  VERSION = "5.0.0".freeze
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This applies a number of changes to the Content Security Policy provided by this gem. It:

- removes unsafe_inline from script-src ~and style-src~, which means that any usages of `<script>` ~or `<style>`~ elements requires a nonce ~and usage of inline styles are forbidden~. This is to limit the damage an attacker can do with ability to inject HTML into a page. (Note: I wasn't able to disable unsafe-inline on style due to [Govspeak](https://github.com/alphagov/govspeak/blob/5642fcc4231f215d1c58ad7feb30ca42fb8cfb91/lib/govspeak/html_sanitizer.rb#L72-L73) usage) 
- removes ability to embed images with `data:` URLs. This limits any injected HTML to not display arbitrary images
- disallows a `<base>` element. This limits the ability of injected HTML to change the destination of scripts and allow execution of 3rd party JavaScript

This has been opened as a draft while frontend applications are checked for blocking issues:

- [x] collections (uses inline script tags for structured data, nonces not required for `<script type="application/ld+json">`)
- [x] email-alert-frontend
- [x] feedback
- [x] finder-frontend (fixed in https://github.com/alphagov/finder-frontend/pull/2976)
- [x] frontend (uses inline script tags for structured data, nonces not required for `<script type="application/ld+json">`)
- [x] government-frontend (fixed in https://github.com/alphagov/government-frontend/pull/2661)
- [x] info-frontend
- [x] licence-finder (fixed in https://github.com/alphagov/licence-finder/pull/1280)
- [x] service-manual-frontend
- [x] smart-answers (fixed in https://github.com/alphagov/smart-answers/pull/6277)
- [x] static (has some inline script tags in error pages (not under CSP) and old files that don't seem to be used on public GOV.UK)
- [x] whitehall (does not use CSP currently)

This is intended to be the draft of the CSP that GOV.UK applies as its initial live offering. Hopefully we will be ready to go once the above list is completed and that we've run this on apps in report only mode for a couple of weeks.

There are some future things I considered out of scope for now:

- [`strict-dynamic`](https://content-security-policy.com/strict-dynamic/) - we probably should switch to `strict-dynamic` for scripts in time, as it is a clear improvement. However, as you have to set-up a bunch of extra backwards compatibility changes, I think it makes things extra complicated when we may have some apps still needing things like unsafe-inline for legacy jQuery. Therefore I think this is something to dig into once live.
- nonces in all script elements, we might want to reduce our script-src allow list and just set nonce attributes, indeed https://csp-evaluator.withgoogle.com/ raises concerns that some of our allow-list could be hosts at risk of serving dubious scripts. This wouldn't be achiveable without adopting `strict-dynamic` so we'll reserve this for that.
- [`require-trusted-types-for 'script'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) this is recommended by https://csp-evaluator.withgoogle.com/. Implementation looks very difficult, as it requires identifying every case of `innerHTML` being called, likely extra challenging because of incomplete browser support currently. So I don't see us being able to support this in the forseeable future.