### PR TITLE
Prevent rabbit user details from being sent to sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Scrub sensitive RabbitMQ data from sentry messages before sending them
+
 # 4.13.0
 
 * Flush log writes to stdout immediately so that structured (JSON) logs are not lost on crash or delayed indefinitely.

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -126,7 +126,7 @@ module GovukError
       lambda do |event, hint|
         result = event
         @before_send_callbacks.each do |callback|
-          result = callback.call(event, hint)
+          result = callback.call(result, hint)
           break if result.nil?
         end
         result


### PR DESCRIPTION
When we complete the switch to amazonmq in all environments, we will be using rabbit mq urls to connect to rabbit in each app. Since the url contains the password and username, we need to suppress this information in any error message, while still sending the error to sentry - example error message we want to change is https://sentry.io/organizations/govuk/issues/3798011523/?project=202242

This PR uses a before send callback with regex to detect when a message contains sensitive information, and logic to substitute just the password in the message for a censored version.

[Trello](https://trello.com/c/zwjYUZl5/429-fix-issue-with-sentry-error-reporting-including-the-usernamepassword-as-part-of-the-rabbitmqurl)