### PR TITLE
Allow us to force-load the Prometheus Exporter...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.0
+
+* Add support to force-load the GovukPrometheusExporter by setting `GOVUK_PROMETHEUS_EXPORTER` to `force`. ([#282](https://github.com/alphagov/govuk_app_config/pull/282))
+
 # 5.0.0
 
 * Forbid base elements in the Content Security Policy

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -1,6 +1,9 @@
 module GovukPrometheusExporter
   def self.should_configure
-    if File.basename($PROGRAM_NAME) == "rake" ||
+    # Allow us to force the Prometheus Exporter for persistent Rake tasks...
+    if ENV["GOVUK_PROMETHEUS_EXPORTER"] == "force"
+      true
+    elsif File.basename($PROGRAM_NAME) == "rake" ||
         defined?(Rails) && (Rails.const_defined?("Console") || Rails.env == "test")
       false
     else

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "5.0.0".freeze
+  VERSION = "5.1.0".freeze
 end


### PR DESCRIPTION
## What?
The Exporter currently ignores the `GOVUK_PROMETHEUS_EXPORTER` environment variable if it detects it is being called by rake.

As the email-alerts-service is a perpetual rake task, we need a way to override this for the time being.

This should allow us to set the `GOVUK_PROMETHEUS_EXPORTER` to `"force"` to make it configure the Prometheus Exporter regardless of whether it is being called by `rake` or not.

## Related PRs

* https://github.com/alphagov/email-alert-service/pull/617