### PR TITLE
Replace underscore method with gsub

### DIFF
--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -116,7 +116,7 @@ module GovukError
       lambda { |event, hint|
         if hint[:exception]
           GovukStatsd.increment("errors_occurred")
-          GovukStatsd.increment("error_types.#{hint[:exception].class.name.split('::').last.underscore}")
+          GovukStatsd.increment("error_types.#{hint[:exception].class.name.split('::').last.gsub(/([^\^])([A-Z])/, '\1_\2').downcase}")
         end
         event
       }


### PR DESCRIPTION
This was using the method `underscore` which is a rails method. However it was being called from places that did not have rails e.g. the cache clearing service resulting in an error.

So we have replaced the rails method with a ruby one that should be able to be run in more applications.