### PR TITLE
Release v6.0.0 and add Prometheus support for Sinatra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## 6.0.0
 
-* Drop support for Ruby 2.7.
+* BREAKING: Drop support for Ruby 2.7
+* Register the Prometheus exporter in Sinatra middleware
 
 # 5.1.0
 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -40,5 +40,9 @@ module GovukPrometheusExporter
     if defined?(Rails)
       Rails.application.middleware.unshift PrometheusExporter::Middleware
     end
+
+    if defined?(Sinatra)
+      Sinatra.use PrometheusExporter::Middleware
+    end
   end
 end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "5.1.0".freeze
+  VERSION = "6.0.0".freeze
 end


### PR DESCRIPTION
At present, [we include this module](https://github.com/alphagov/search-api/blob/1b881b0ff1f2c6d65bc02d30b1f323ccd0633029/config/initializers/prometheus.rb#L2) but it doesn't seem to get plumbed into middleware.

This affects search-api and bouncer.

When I deployed a branch of search-api to integration referencing this branch, metrics appeared almost immediately

![Screenshot 2023-03-29 at 09 29 22](https://user-images.githubusercontent.com/773037/228474512-bae8c29a-8c5f-4bea-b091-5b8a55436dae.png)
