### PR TITLE
Allow puma timeout to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+* Add support for configuring timeouts for puma-based applications
+
 ## 6.0.0
 
 * BREAKING: Drop support for Ruby 2.7

--- a/lib/govuk_app_config/govuk_puma.rb
+++ b/lib/govuk_app_config/govuk_puma.rb
@@ -9,7 +9,11 @@ module GovukPuma
     end
 
     # `worker_timeout` specifies how many seconds Puma will wait before terminating a worker.
-    timeout = ENV.fetch("RAILS_ENV", "development") == "development" ? 3600 : 15
+    timeout = if ENV.fetch("RAILS_ENV", "development") == "development"
+                3600
+              else
+                Integer(ENV.fetch("PUMA_TIMEOUT", 15))
+              end
     config.worker_timeout timeout
 
     # When changing the min/max threads for Puma, also consider changing ActiveRecord to match.


### PR DESCRIPTION
This will allow us to set a different timeout for production systems. The need for this arose because of timing out requests for HMRC manuals api, which we [allowed for configuration of](https://github.com/alphagov/govuk_app_config/blob/c68fb5816906bde162d95e8c2738cde9f8f1d1d1/lib/govuk_app_config/govuk_unicorn.rb#L5) when it was unicorn- rather than puma-based.

I'll release this in a follow-up PR.

[Trello](https://trello.com/c/qtpjC3PB/556-increase-timeout-for-hmrc-manuals-api)