### PR TITLE
7.1.0: Remove hardcoded allowlist of Sentry environment names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
+# 7.1.0
+
+* `GovukError` now allows specifying any name for the Sentry environment tag via the `SENTRY_CURRENT_ENV` environment variable. The environment name no longer has to match one of a fixed set of strings in order for `GovukError` to log events to Sentry.
+
 # 7.0.0
 
 * BREAKING: Remove [unicorn](https://rubygems.org/gems/unicorn/) and `GovukUnicorn`. All production GOV.UK apps are now using [Puma](https://rubygems.org/gems/puma/) instead.
 * `GovukStatsd` is deprecated and will be removed in a future major release.
 
-## 6.0.1
+# 6.0.1
 
 * Add support for configuring timeouts for puma-based applications
 
-## 6.0.0
+# 6.0.0
 
 * BREAKING: Drop support for Ruby 2.7
 * Register the Prometheus exporter in Sinatra middleware

--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ To run an app locally with Puma, run: `bundle exec puma` or `bundle exec rails s
 
 ### Automatic error reporting
 
-If you include `govuk_app_config` in your `Gemfile`, Rails' autoloading mechanism will make sure that your application is configured to send errors to Sentry.
-
-Your app will have to have the following environment variables set:
+If you include `govuk_app_config` in your `Gemfile` and set the following environment variables, your application will automatically log errors to Sentry.
 
 - `SENTRY_DSN` - the [Data Source Name (DSN)][dsn] for Sentry
-- `SENTRY_CURRENT_ENV` - e.g. "production". Make sure it is [configured to be active](#active-sentry-environments).
-- `GOVUK_STATSD_PREFIX` - a Statsd prefix like `govuk.apps.application-name.hostname` (deprecated; use Prometheus instead).
+- `SENTRY_CURRENT_ENV` - the `environment` tag to pass to Sentry, for example `production`
+- `GOVUK_STATSD_PREFIX` - a Statsd prefix like `govuk.apps.application-name.hostname` (deprecated; statsd functionality will be removed in a future release)
 
 [dsn]: https://docs.sentry.io/quickstart/#about-the-dsn
 
@@ -71,18 +69,6 @@ GovukError.notify(
   level: "debug", # debug, info, warning, error, fatal
   tags: { key: "value" } # Tags to index with this event. Must be a mapping of strings.
 )
-```
-
-### Active Sentry environments
-
-GovukError will only send errors to Sentry if your `SENTRY_CURRENT_ENV` matches one of the 'active environments' in the [default configuration](https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_error/configure.rb). This is to prevent temporary test environments from flooding our Sentry account with errors.
-
-You can add your environment to the list of active Sentry environments like so:
-
-```ruby
-GovukError.configure do |config|
-  config.enabled_environments << "my-test-environment"
-end
 ```
 
 ### Error configuration

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -13,19 +13,6 @@ module GovukError
     end
 
     def set_up_defaults
-      # These are the environments (described by the `SENTRY_CURRENT_ENV`
-      # ENV variable) where we want to capture Sentry errors. If
-      # `SENTRY_CURRENT_ENV` isn't in this list, or isn't defined, then
-      # don't capture the error.
-      self.enabled_environments = %w[
-        integration-blue-aws
-        integration-eks
-        staging
-        staging-eks
-        production
-        production-eks
-      ]
-
       self.excluded_exceptions = [
         # Default ActionDispatch rescue responses
         "ActionController::RoutingError",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "7.0.0".freeze
+  VERSION = "7.1.0".freeze
 end


### PR DESCRIPTION
`active_sentry_environments` was a hard-coded list of allowable values for the Sentry `environment` tag. It was [introduced](https://www.github.com/alphagov/govuk_app_config/pull/168) during the Replatforming discovery phase in 2020 in order to prevent the Puppet/EC2 stack in the test account from sending events to Sentry.

(It was done this way because at that time, disabling Sentry in the test environment was more difficult than it should have been, while some teams had Sentry alerts and Slack subscriptions which didn't select by environment).

We don't need this feature any more and we're now better off without it, because it complicated the semantics of `SENTRY_CURRENT_ENV` in a way that is surprising to the user.

This fixes a current problem where apps in the integration cluster are unable to send events to Sentry.

If we want to run without Sentry in future, we can just not set `SENTRY_DSN`.

Rollout: requires all the affected apps to update to govuk_app_config 7.1 (i.e. this release) in order for the fix to take effect :(