### PR TITLE
Forbid unsafe-inline for style attributes in CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 8.0.0
 
 * BREAKING: Content Security Policy forbids the use of inline style attributes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Content Security Policy forbids the use of inline style attributes.
+
 # 7.2.1
 
 * Allow prometheus binding to fail with a warning rather than a crash ([#294](https://github.com/alphagov/govuk_app_config/pull/294))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -56,17 +56,10 @@ module GovukContentSecurityPolicy
                       "www.youtube-nocookie.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
-    # Note: we purposely don't include `data:` or `unsafe-eval` because
+    # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
     # they are security risks, if you need them for a legacy app please only apply them at
     # an app level.
-    policy.style_src :self,
-                     *GOOGLE_STATIC_DOMAINS,
-                     # This allows `style=""` attributes and `<style>` elements.
-                     # As of January 2023 our intentions to remove this were scuppered
-                     # by Govspeak [1] using inline styles on tables. Until that
-                     # is resolved we'll keep unsafe_inline
-                     # [1]: https://github.com/alphagov/govspeak/blob/5642fcc4231f215d1c58ad7feb30ca42fb8cfb91/lib/govspeak/html_sanitizer.rb#L72-L73
-                     :unsafe_inline
+    policy.style_src :self, *GOOGLE_STATIC_DOMAINS
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
     # Note: we purposely don't include data here because it produces a security risk.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "7.2.1".freeze
+  VERSION = "8.0.0".freeze
 end


### PR DESCRIPTION
This continues the work from https://github.com/alphagov/govuk_app_config/pull/279 to remove risky properties from our Content Security Policy (CSP) by removing unsafe-inline from style properties.

We have been able to resolve the need for this property by updating Govspeak [1].

I've marked this as a breaking change as it forbids something fundamental, however this is really quite a soft breaking change as a) there has been lots of prep work across GOV.UK to prepare for it and b) the CSP is in report only mode across GOV.UK so won't actually block any usages.

~Prior to merging this we need to represent any content that uses tables with text alignment to the Publishing API to remove their inline styles. I've opened this as a draft while this is completed.~
Edit: 2 June, I've been through and removed nearly all usages of style. I'm now going to utilise the CSP reports to catch other ones. 

[1]: https://github.com/alphagov/govspeak/pull/268