### PR TITLE
Add Puma::HttpParserError to excluded exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Suppress noisy Puma::HttpParserError errors
+
 # 7.1.0
 
 * `GovukError` now allows specifying any name for the Sentry environment tag via the `SENTRY_CURRENT_ENV` environment variable. The environment name no longer has to match one of a fixed set of strings in order for `GovukError` to log events to Sentry.

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -41,6 +41,7 @@ module GovukError
         "GdsApi::HTTPIntermittentServerError",
         "GdsApi::TimedOutException",
         "Mongoid::Errors::DocumentNotFound",
+        "Puma::HttpParserError",
         "Sinatra::NotFound",
         "Slimmer::IntermittentRetrievalError",
         "Sidekiq::JobRetry::Skip",


### PR DESCRIPTION
Add HttpParserError to excluded exceptions
    
Sentry ruby 5.9 ensured that low level puma errors were captured and propagated to sentry. This ended up in a lot of noise [1] in sentry when applications were bumped to this version of sentry ruby, particularly with Puma::HttpParser errors.
    
These errors are often unactionable and we believe a result of crawler activity. This suppresses these errors in order to reduce sentry noise.
    
1: https://govuk.sentry.io/issues/4154286086/?project=202217