### PR TITLE
Fix dropped logs due to incorrect source field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.1
+
+* Change the "source" field in Rails logs from logstasher from string representing IP host address to an empty object. 
+
 # 8.0.0
 
 * BREAKING: Content Security Policy forbids the use of inline style attributes.

--- a/lib/govuk_app_config/govuk_logging.rb
+++ b/lib/govuk_app_config/govuk_logging.rb
@@ -48,6 +48,10 @@ module GovukLogging
     Rails.application.config.logstasher.view_enabled = false
     Rails.application.config.logstasher.job_enabled = false
 
+    # Elasticsearch index expect source to be an object and logstash defaults
+    # source to be the host IP address causing logs to be dropped.
+    Rails.application.config.logstasher.source = {}
+
     Rails.application.config.logstasher.logger = Logger.new(
       $real_stdout, # rubocop:disable Style/GlobalVars
       level: Rails.logger.level,

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "8.0.0".freeze
+  VERSION = "8.0.1".freeze
 end


### PR DESCRIPTION
The logstash gem adds a field to logs called "source" and by defaults sets it a string representing the host IP address. Our Elasticsearch mapping expect source to be of type object, to support subfield such as source.ip or source.address etc. This causes Elasticsearch to drop the logs resulting in missing Rails logs.

There's currently no way to rename the field (as the field is added after the logstasher's renaming config) and it cannot be disabled. This field is of limited use as the value is usually just the K8s pod IP address.