### PR TITLE
Require sidekiq/api in GovukPrometheusExporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 8.0.2
 
 * Fix the ability to collect Sidekiq metrics in GovukPrometheusExporter. ([#299](https://github.com/alphagov/govuk_app_config/pull/299))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix the ability to collect Sidekiq metrics in GovukPrometheusExporter. ([#299](https://github.com/alphagov/govuk_app_config/pull/299))
+
 # 8.0.1
 
 * Change the "source" field in Rails logs from logstasher from string representing IP host address to an empty object. 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -20,6 +20,7 @@ module GovukPrometheusExporter
 
     if defined?(Sidekiq)
       Sidekiq.configure_server do |config|
+        require "sidekiq/api"
         require "prometheus_exporter/instrumentation"
         config.server_middleware do |chain|
           chain.add PrometheusExporter::Instrumentation::Sidekiq

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "8.0.1".freeze
+  VERSION = "8.0.2".freeze
 end


### PR DESCRIPTION
## Why

The workers were erroring with:
```
PrometheusExporter::Instrumentation::SidekiqProcess Prometheus Exporter Failed
To Collect Stats uninitialized constant Sidekiq::Process
PrometheusExporter::Instrumentation::SidekiqQueue Prometheus Exporter Failed To
Collect Stats uninitialized constant Sidekiq::Queue
PrometheusExporter::Instrumentation::SidekiqStats Prometheus Exporter Failed To
Collect Stats uninitialized constant Sidekiq::Stats
```

and failing to send metrics following a switch from Statsd to Prometheus Exporter: https://github.com/alphagov/govuk_sidekiq/commit/763144dd055ab286a020902e7d63a21eec428155

Sidekiq::Process, Sidekiq::Queue, Sidekiq::Stats are defined in Sidekiq API. It appears that to get access to the functionality, the API needs to be required. See https://github.com/sidekiq/sidekiq/wiki/API

Resolves https://github.com/alphagov/govuk_app_config/issues/298

## Testing
Tested in integration. Logs showing no errors

<kbd><img width="1019" alt="Screenshot 2023-06-15 at 11 19 20" src="https://github.com/alphagov/govuk_app_config/assets/38078064/468e6422-3520-46a3-a8b0-52bf9717c256"></kbd>