### PR TITLE
Enable production-like logs if env variable is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: JSON logs are no longer configured automatically for production Rails apps and are turned on with the GOVUK_RAILS_JSON_LOGGING environment variable ([#302](https://github.com/alphagov/govuk_app_config/pull/302))
+
 # 8.1.1
 
 * Fix prometheus_exporter to method patching compatible with open telemetry.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ check docs](docs/healthchecks.md) for more information on how to use it.
 In Rails applications, the application will be configured to send JSON-formatted
 logs to `STDOUT` and unstructured logs to `STDERR`.
 
+To enable production-like logging, an env variable `GOVUK_RAILS_JSON_LOGGING`
+is set in the `govuk-helm-charts` and then checked in `railtie.rb`. This will
+allow JSON format logs and `Govuk-Request-Id` to be visible.
+
+For development logs, in order to see the production style logs, developers should
+set `GOVUK_RAILS_JSON_LOGGING`in `govuk-docker` -> `docker-compose` files.
+
 
 ## Content Security Policy generation
 

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -7,7 +7,7 @@ require "govuk_app_config/govuk_open_telemetry"
 require "govuk_app_config/govuk_prometheus_exporter"
 
 if defined?(Rails)
-  require "govuk_app_config/govuk_logging"
+  require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_content_security_policy"
   require "govuk_app_config/railtie"
 end

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -2,7 +2,7 @@ require "logstasher"
 require "action_controller"
 require_relative "rails_ext/action_dispatch/debug_exceptions"
 
-module GovukLogging
+module GovukJsonLogging
   def self.configure
     # GOV.UK Rails applications are expected to output JSON to stdout which is
     # then indexed in a Kibana instance. These log outputs are created by the

--- a/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
+++ b/lib/govuk_app_config/rails_ext/action_dispatch/debug_exceptions.rb
@@ -1,6 +1,6 @@
 require "action_dispatch/middleware/debug_exceptions"
 
-module GovukLogging
+module GovukJsonLogging
   module RailsExt
     module ActionDispatch
       def self.should_monkey_patch_log_error?(clazz = ::ActionDispatch::DebugExceptions)

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -13,7 +13,7 @@ module GovukAppConfig
     end
 
     config.before_initialize do
-      GovukLogging.configure if Rails.env.production?
+      GovukJsonLogging.configure if ENV["GOVUK_RAILS_JSON_LOGGING"]
     end
 
     config.after_initialize do

--- a/spec/lib/govuk_json_logging_spec.rb
+++ b/spec/lib/govuk_json_logging_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 require "rails"
-require "govuk_app_config/govuk_logging"
+require "govuk_app_config/govuk_json_logging"
 require "rack/test"
 
-RSpec.describe GovukLogging do
+RSpec.describe GovukJsonLogging do
   before do
     stub_const("DummyLoggingRailsApp", Class.new(Rails::Application) do
       config.hosts.clear
@@ -35,19 +35,19 @@ RSpec.describe GovukLogging do
   describe ".configure" do
     it "enables logstasher" do
       Rails.application.config.logstasher.enabled = false
-      expect { GovukLogging.configure }
+      expect { GovukJsonLogging.configure }
         .to change { Rails.application.config.logstasher.enabled }
         .to(true)
     end
 
     it "initialises a logstasher logger using the rails logger level" do
-      GovukLogging.configure
+      GovukJsonLogging.configure
       expect(Rails.application.config.logstasher.logger.level)
         .to eq(info_log_level)
     end
 
     it "can write to logstasher log" do
-      GovukLogging.configure
+      GovukJsonLogging.configure
       logger = Rails.application.config.logstasher.logger
       logger.info("test log entry")
       fake_stdout.rewind
@@ -56,7 +56,7 @@ RSpec.describe GovukLogging do
     end
 
     it "can write to default rails logger" do
-      GovukLogging.configure
+      GovukJsonLogging.configure
       logger = Rails.logger
       logger.info("test default log entry")
       $stderr.rewind
@@ -72,7 +72,7 @@ RSpec.describe GovukLogging do
       end
 
       it "logs errors thrown by the application" do
-        GovukLogging.configure
+        GovukJsonLogging.configure
         get "/error"
         $stderr.rewind
         lines = $stderr.read.split("\n")

--- a/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/lib/rails_ext/action_dispatch/debug_exceptions_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "rails"
 require "govuk_app_config/rails_ext/action_dispatch/debug_exceptions"
 
-RSpec.describe ::GovukLogging::RailsExt::ActionDispatch do
+RSpec.describe ::GovukJsonLogging::RailsExt::ActionDispatch do
   describe "#should_monkey_patch_log_error?" do
     before do
       Rails.logger = double(:rails_logger)


### PR DESCRIPTION
This is to allow setting production-like behaviour by using the `ENABLE_PRODUCTION_LIKE_LOGS` env variable. This will be set in `govuk-heml-charts` -> `env-configmap.yaml`. The purpose is to allow developers to override this env var in order to test changes to production logs locally.

[Trello card](https://trello.com/c/niLCNflj/117-story-enable-production-like-logging-in-dev-environments)