### PR TITLE
Add support Open Telemetry instrumentation in Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.0
+
+* Add ability to enable Open Telemetry instrumentation for Rails applications.
+
 # 8.0.2
 
 * Fix the ability to collect Sidekiq metrics in GovukPrometheusExporter. ([#299](https://github.com/alphagov/govuk_app_config/pull/299))

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ end
 
 `GovukError.configure` has the same options as the Sentry client, Raven. See [the Raven docs for all configuration options](https://docs.sentry.io/clients/ruby/config).
 
+## Open Telemetry
+
+To enable Open Telemetry instrumentation for Rails set the ENABLE_OPEN_TELEMETRY="true" environment variable.
 
 ## Prometheus monitoring
 

--- a/govuk_app_config.gemspec
+++ b/govuk_app_config.gemspec
@@ -21,6 +21,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "logstasher", "~> 2.1"
+  spec.add_dependency "opentelemetry-exporter-otlp", "~> 0.25.0"
+  spec.add_dependency "opentelemetry-instrumentation-all", "~> 0.39.1"
+  spec.add_dependency "opentelemetry-sdk", "~> 1.2"
   spec.add_dependency "plek", ">= 4", "< 6"
   spec.add_dependency "prometheus_exporter", "~> 2.0"
   spec.add_dependency "puma", ">= 5.6", "< 7.0"

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -3,6 +3,7 @@ require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
 require "govuk_app_config/govuk_proxy/static_proxy"
 require "govuk_app_config/govuk_healthcheck"
+require "govuk_app_config/govuk_open_telemetry"
 require "govuk_app_config/govuk_prometheus_exporter"
 
 if defined?(Rails)

--- a/lib/govuk_app_config/govuk_open_telemetry.rb
+++ b/lib/govuk_app_config/govuk_open_telemetry.rb
@@ -1,0 +1,18 @@
+module GovukOpenTelemetry
+  def self.should_configure?
+    ENV["ENABLE_OPEN_TELEMETRY"] == "true"
+  end
+
+  def self.configure(service_name)
+    return unless should_configure?
+
+    require "opentelemetry/sdk"
+    require "opentelemetry/exporter/otlp"
+    require "opentelemetry/instrumentation/all"
+
+    OpenTelemetry::SDK.configure do |config|
+      config.service_name = service_name
+      config.use_all # enables all instrumentation!
+    end
+  end
+end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -8,6 +8,10 @@ module GovukAppConfig
       end
     end
 
+    initializer "govuk_app_config.configure_open_telemetry" do |app|
+      GovukOpenTelemetry.configure(app.class.module_parent_name.underscore)
+    end
+
     config.before_initialize do
       GovukLogging.configure if Rails.env.production?
     end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "8.0.2".freeze
+  VERSION = "8.1.0".freeze
 end


### PR DESCRIPTION
This adds the ability to enable Open Telemetry instrumentation in Rails by setting the "ENABLE_OPEN_TELEMETRY" environment variable to "true".

The service name is automatic set to the Rails application name.

---
This is work done part as GIFT week and should initially only be enabled in integration. Should be removed if ultimately not implemented/used. 