### PR TITLE
Fix prometheus_exporter to method patching compatible with open telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.1
+
+* Fix prometheus_exporter to method patching compatible with open telemetry.
+
 # 8.1.0
 
 * Add ability to enable Open Telemetry instrumentation for Rails applications.

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -40,7 +40,7 @@ module GovukPrometheusExporter
       server.start
 
       if defined?(Rails)
-        Rails.application.middleware.unshift PrometheusExporter::Middleware
+        Rails.application.middleware.unshift PrometheusExporter::Middleware, instrument: :prepend
       end
 
       if defined?(Sinatra)

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "8.1.0".freeze
+  VERSION = "8.1.1".freeze
 end


### PR DESCRIPTION
This switches prometheus_exporter's method patching to use `prepend` instead of `alias_method`. Prepend is negligibly slower than alias_method, but is more compatible other libraries.

https://github.com/discourse/prometheus_exporter#choosing-the-style-of-method-patching

https://samsaffron.com/archive/2017/10/18/fastest-way-to-profile-a-method-in-ruby#fastest-way-to-patch-a-method-3

The issues with alias method cause a recursive call between prometheus_exporter and open telemetry sdk when making calls to SQL and redis.