### PR TITLE
Fix dropped logs due to incorrect error field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.1
+
+* Rename the "error" field in Rails logs from logstasher to "message" as error is supposed to be an object.
+
 # 9.0.0
 
 * BREAKING: JSON logs are no longer configured automatically for production Rails apps and are turned on with the GOVUK_RAILS_JSON_LOGGING environment variable ([#302](https://github.com/alphagov/govuk_app_config/pull/302))

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -50,6 +50,11 @@ module GovukJsonLogging
     # Elasticsearch index expect source to be an object and logstash defaults
     # source to be the host IP address causing logs to be dropped.
     Rails.application.config.logstasher.source = {}
+    # Elasticsearch index expect error to be an object and logstash defaults
+    # error to be a string causing logs to be dropped.
+    Rails.application.config.logstasher.field_renaming = {
+      error: :message,
+    }
 
     Rails.application.config.logstasher.logger = Logger.new(
       $stdout,

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.0.0".freeze
+  VERSION = "9.0.1".freeze
 end


### PR DESCRIPTION
Kibana validates log lines by index patterns and "error" is supposed to be an object. Since error is a string in logstaher's world we are renaming it to "message" which will be accepted as string.