### PR TITLE
Don't init OpenTelemetry when in `rails console`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.2
+
+* GovukAppConfig no longer automatically initialises OpenTelemetry when running in `rails console`.
+
 # 9.0.1
 
 * Rename the "error" field in Rails logs from logstasher to "message" as error is supposed to be an object.
@@ -12,11 +16,11 @@
 
 # 8.1.1
 
-* Fix prometheus_exporter to method patching compatible with open telemetry.
+* Fix prometheus_exporter to method patching compatible with OpenTelemetry.
 
 # 8.1.0
 
-* Add ability to enable Open Telemetry instrumentation for Rails applications.
+* Add ability to enable OpenTelemetry instrumentation for Rails applications.
 
 # 8.0.2
 

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -9,7 +9,9 @@ module GovukAppConfig
     end
 
     initializer "govuk_app_config.configure_open_telemetry" do |app|
-      GovukOpenTelemetry.configure(app.class.module_parent_name.underscore)
+      unless Rails.const_defined?(:Console)
+        GovukOpenTelemetry.configure(app.class.module_parent_name.underscore)
+      end
     end
 
     config.before_initialize do

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.0.1".freeze
+  VERSION = "9.0.2".freeze
 end


### PR DESCRIPTION
This fixes a bunch of annoying warnings on startup, avoids generating traces from interactive use by default, and possibly reduces the chance of OOM when execing `rails console` inside a serving app container.

(Thought about putting the condition in `GovukOpenTelemetry::should_configure?` but given that the condition is specific to the Rails use case, the Railtie seemed like the better/cleaner place to put it.)