### PR TITLE
Log error messages as error_message instead of message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.3
+
+* When error is reported by Rails logger, the field is now logged as "error_message" in order to avoid overwriting the "message" field.
+
 # 9.0.2
 
 * GovukAppConfig no longer automatically initialises OpenTelemetry when running in `rails console`.

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -53,7 +53,7 @@ module GovukJsonLogging
     # Elasticsearch index expect error to be an object and logstash defaults
     # error to be a string causing logs to be dropped.
     Rails.application.config.logstasher.field_renaming = {
-      error: :message,
+      error: :error_message,
     }
 
     Rails.application.config.logstasher.logger = Logger.new(

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.0.2".freeze
+  VERSION = "9.0.3".freeze
 end


### PR DESCRIPTION
Previously the library logged Rails error messages as "message" field, which would overwrite the message field in Kibana. Log them as "error_message" instead to avoid confusion.