### PR TITLE
Use ActiveSupport::Logger instead of Ruby std Logger for the Rails apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.4
+
+* Fix an issue with Rails.logger being not an instance of ActiveSupport::Logger. Rails expects Rails.logger to have methods that Ruby STD Logger does not provide. e.g. `silence()` ([#309](https://github.com/alphagov/govuk_app_config/pull/309))
+
 # 9.0.3
 
 * When error is reported by Rails logger, the field is now logged as "error_message" in order to avoid overwriting the "message" field.

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -8,24 +8,21 @@ module GovukJsonLogging
     # indefinitely while troubleshooting.
     $stdout.sync = true
 
-    Rails.logger = Logger.new(
-      $stdout,
-      level: Rails.logger.level,
-      formatter: proc { |severity, datetime, _progname, msg|
-        hash = {
-          "@timestamp": datetime.utc.iso8601(3),
-          message: msg,
-          level: severity,
-          tags: %w[rails],
-        }
+    Rails.logger = ActiveSupport::Logger.new($stdout, level: Rails.logger.level)
+    Rails.logger.formatter = proc { |severity, datetime, _progname, msg|
+      hash = {
+        "@timestamp": datetime.utc.iso8601(3),
+        message: msg,
+        level: severity,
+        tags: %w[rails],
+      }
 
-        if defined?(GdsApi::GovukHeaders) && !GdsApi::GovukHeaders.headers[:govuk_request_id].nil?
-          hash[:govuk_request_id] = GdsApi::GovukHeaders.headers[:govuk_request_id]
-        end
+      if defined?(GdsApi::GovukHeaders) && !GdsApi::GovukHeaders.headers[:govuk_request_id].nil?
+        hash[:govuk_request_id] = GdsApi::GovukHeaders.headers[:govuk_request_id]
+      end
 
-        "#{hash.to_json}\n"
-      },
-    )
+      "#{hash.to_json}\n"
+    }
 
     LogStasher.add_custom_fields do |fields|
       # Mirrors Nginx request logging, e.g. GET /path/here HTTP/1.1

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.0.3".freeze
+  VERSION = "9.0.4".freeze
 end


### PR DESCRIPTION
Rails libraries expect the `Rails.logger` instance to inherit from ActiveSupport::Logger. The ruby standard library logger for example does not implement methods like `silence` which is used by some of the Rails internals. 

This change fixes the inheritance issue.

Co-authored-by: laura.ghiorghisor@digital.cabinet-office.gov.uk


This fixes the below error:
<img width="1642" alt="Screenshot 2023-07-17 at 11 04 05" src="https://github.com/alphagov/govuk_app_config/assets/297901/2083ddaa-102f-43ab-9a99-870f356b1073">

The error appears in development environment when Production like logging is enabled.

Tested with happy results:
<img width="801" alt="image" src="https://github.com/alphagov/govuk_app_config/assets/297901/5146b264-6da8-4031-af51-e4001e04d44d">

