### PR TITLE
GovukAppConfig silences OpenTelemetry log output when running a rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* GovukAppConfig silences OpenTelemetry log output when running a rake task ([#311](https://github.com/alphagov/govuk_app_config/pull/311))
+
 # 9.0.4
 
 * Fix an issue with Rails.logger being not an instance of ActiveSupport::Logger. Rails expects Rails.logger to have methods that Ruby STD Logger does not provide. e.g. `silence()` ([#309](https://github.com/alphagov/govuk_app_config/pull/309))
@@ -36,7 +40,7 @@
 
 # 8.0.1
 
-* Change the "source" field in Rails logs from logstasher from string representing IP host address to an empty object. 
+* Change the "source" field in Rails logs from logstasher from string representing IP host address to an empty object.
 
 # 8.0.0
 

--- a/lib/govuk_app_config/govuk_open_telemetry.rb
+++ b/lib/govuk_app_config/govuk_open_telemetry.rb
@@ -13,6 +13,11 @@ module GovukOpenTelemetry
     OpenTelemetry::SDK.configure do |config|
       config.service_name = service_name
       config.use_all # enables all instrumentation!
+      config.logger = Logger.new(File::NULL) if in_rake_task?
     end
+  end
+
+  def self.in_rake_task?
+    Rails.const_defined?(:Rake) && Rake.application.top_level_tasks.any?
   end
 end


### PR DESCRIPTION
https://github.com/alphagov/govuk_app_config/pull/307 removes OpenTelemetry initialisation in the console to avoid flooding the console with OpenTelemetry startup messages.

This PR adds the additional behaviour that when OpenTelemetry _is_ configured (ie we are not on a console), we do a second check to see whether we're in a rake task and silence OpenTelemetry log messages so that Rake tasks with simple text output are not swamped with OpenTelemetry startup messages.

Since we're already assuming Rails.const_defined? is available, we use it to check for Rake, then call Rake.application.top_level tasks, which returns an empty array if running in rails, but a list of tasks if running through rake.