### PR TITLE
Update warning about address in use for Prometheus metrics server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * GovukAppConfig silences OpenTelemetry log output when running a rake task ([#311](https://github.com/alphagov/govuk_app_config/pull/311))
+* Update warning message for Prometheus metric server address already in use.
 
 # 9.0.4
 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -47,7 +47,7 @@ module GovukPrometheusExporter
         Sinatra.use PrometheusExporter::Middleware
       end
     rescue Errno::EADDRINUSE
-      warn "Warning: Could not connect to Prometheus Server"
+      warn "Could not start Prometheus metrics server as address already in use."
     end
   end
 end


### PR DESCRIPTION
This makes the warning message less confusing, as error is about the Prometheus metrics server failing to start rather than being unable to connect to Prometheus itself.