### PR TITLE
Add ability to specify custom collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * GovukAppConfig silences OpenTelemetry log output when running a rake task ([#311](https://github.com/alphagov/govuk_app_config/pull/311))
 * Update warning message for Prometheus metric server address already in use.
+* Add ability to support custom collectors in the Prometheus exporter.
 
 # 9.0.4
 

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -11,7 +11,7 @@ module GovukPrometheusExporter
     end
   end
 
-  def self.configure
+  def self.configure(collectors: [])
     return unless should_configure
 
     require "prometheus_exporter"
@@ -37,6 +37,9 @@ module GovukPrometheusExporter
 
     begin
       server = PrometheusExporter::Server::WebServer.new bind: "0.0.0.0", port: 9394
+
+      collectors.each { |collector| server.collector.register_collector(collector.new) }
+
       server.start
 
       if defined?(Rails)


### PR DESCRIPTION
This extends application Prometheus exporter configuration to load custom collectors. This is required by application that would like to support global metrics (e.g. user/article counts). Specifically this is need to support Signon provide metrics for token expiry timestamps.

Following the global metrics pattern outlined in the [prometheus_exporter docs](https://github.com/discourse/prometheus_exporter#global-metrics-in-a-custom-type-collector).