### PR TITLE
Disallow any domain from embeding a page to prevent clickjacking

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -80,6 +80,11 @@ module GovukContentSecurityPolicy
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
     policy.frame_src :self, *GOVUK_DOMAINS, "www.youtube.com", "www.youtube-nocookie.com" # Allow youtube embeds
 
+    # Disallow any domain from embeding a page using <frame>, <iframe>, <object>, or <embed> to prevent clickjacking
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
+    policy.frame_ancestors :none
+
     policy.report_uri ENV["GOVUK_CSP_REPORT_URI"] if ENV.include?("GOVUK_CSP_REPORT_URI")
   end
 


### PR DESCRIPTION
## Context
Other sites could iframe GOV.UK into theirs and potentially use CSS/JS clickjacking to capture keystrokes etc.  It was not done before because in 2020 there were a couple of instances where non-origin framing was a valid use case (e.g. we used to a side-by-side browser for sites transitioning content to GOV.UK so the departments could see where their pages will redirect to)

In 2023, the [side-by-side browser](https://docs.publishing.service.gov.uk/repos/side-by-side-browser.html) is now retired, and we now have the GOV.UK Account in place and a potential move towards personalisation, so the likelihood of an attacker attempting to steal GOV.UK credentials is growing.

[Trello card](https://trello.com/c/QC9k1z4a/3303-prevent-iframing-of-govuk-3)

## Changes proposed
Disallow any domain from embeding a page to prevent clickjacking with the HTTP Content-Security-Policy `frame-ancestors`. Decided to use `frame-ancestors` directive rather than `X-Frame-Options` HTTP response header as they have more drawbacks the main one being the fact that they are now deprecated.

## Considerations
We also have some different options for `X-Frame-Options` set in the apps. They will take priority so this PR is safe to merge and release the gem. There will be follow up work to look into these.

### List of individual directives 
Signon: [SAMEORIGIN](https://github.com/alphagov/signon/blob/621d729978f81cfe852b8b06bb4601ebda0c9134/app/controllers/application_controller.rb#L13)
Collections: [ALLOWALL](https://github.com/alphagov/collections/blob/e84a089afab606357bbd11226449c756f113c42d/config/application.rb#L115)
Frontend: [ALLOWALL in application config](https://github.com/alphagov/frontend/blob/75bfde6/config/application.rb#L73), [DENY in content_item controller](https://github.com/alphagov/frontend/blob/6294499818e32ac8686be01b5a2558872c46aaf6/app/controllers/content_items_controller.rb#L64)
Finder Frontend: [ALLOWALL](https://github.com/alphagov/finder-frontend/blob/676ba10b5524dfa2ee5029e02db2fba2cb3bb830/config/application.rb#L39)
Authenticating proxy: [Deletes X-Frame-Options headers](https://github.com/alphagov/authenticating-proxy/blob/766d4ef727d3379ae0dcf422ecf80528a523cc58/lib/proxy.rb#L146)
Content tagger: [has an iframing allowing proxy](https://github.com/alphagov/content-tagger/blob/ab30240e7d656d07e9e64cc60d38439d734a4d99/app/lib/proxies/iframe_allowing_proxy.rb)
Asset manager: [DENY](https://github.com/alphagov/asset-manager/blob/4c7214e20e06ccefeee791c874163ac223bf9c95/app/controllers/media_controller.rb#L144), [nginx config in govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/blob/e10b5b9264e4306d6845d977415f4446ff5b82b8/charts/asset-manager/templates/nginx-configmap.yaml#L209)
govuk_publishing_components (Components guide): [ALLOWALL](https://github.com/alphagov/govuk_publishing_components/blob/c9ca7ca1df85b3801dcfd2981adfcf27a089b397/app/controllers/govuk_publishing_components/application_controller.rb#L11)
datagovuk_find: [DENY](https://github.com/alphagov/datagovuk_find/blob/a1fd2ac1ba5384895586e786601e34202e9b45da/config/application.rb#L66)
datagovuk_publish: [SAMEORIGIN](https://github.com/alphagov/datagovuk_find/blob/a1fd2ac1ba5384895586e786601e34202e9b45da/config/application.rb#L66)