### PR TITLE
Fix GovukContentSecurityPolicy test

### DIFF
--- a/spec/lib/govuk_content_security_policy_spec.rb
+++ b/spec/lib/govuk_content_security_policy_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe GovukContentSecurityPolicy do
 
   describe ".configure" do
     it "creates a policy" do
-      Rails.application.config.content_security_policy = nil
-
       expect { GovukContentSecurityPolicy.configure }
         .to change { Rails.application.config.content_security_policy }
+        .from(nil)
         .to(an_instance_of(ActionDispatch::ContentSecurityPolicy))
     end
 


### PR DESCRIPTION
The test started failing because Rails now prevents meaningless assignments to a configuration key by raising NoMethodError.  See: https://github.com/rails/rails/commit/265bfad5fb7f875dfb3ddfafd895cb2ec80458f7

```
  GovukContentSecurityPolicy.configure creates a policy
     Failure/Error: Rails.application.config.content_security_policy = nil

     NoMethodError:
       Cannot assign to `content_security_policy`, it is a configuration method

                   raise NoMethodError.new("Cannot assign to `#{key}`, it is a configuration method")
                   ^^^^^
     # ./spec/lib/govuk_content_security_policy_spec.rb:14:in `block (3 levels) in <top (required)>'
```