### PR TITLE
Enable adding custom LogStasher fields from apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Enable adding custom LogStasher fields from apps ([#327](https://github.com/alphagov/govuk_app_config/pull/327))
+
 # 9.6.0
 
 * Allow YouTube thumbnails from https://i.ytimg.com in the global Content Security Policy ([#328](https://github.com/alphagov/govuk_app_config/pull/328))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.7.0
 
 * Enable adding custom LogStasher fields from apps ([#327](https://github.com/alphagov/govuk_app_config/pull/327))
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ allow JSON format logs and `Govuk-Request-Id` to be visible.
 For development logs, in order to see the production style logs, developers should
 set `GOVUK_RAILS_JSON_LOGGING`in `govuk-docker` -> `docker-compose` files.
 
+### Logger configuration
+
+To include additional custom fields in your Rails logs, you can declare them
+within a `GovukJsonLogging.configure` block in a `config/initializers/` file.
+
+Example of adding a key/value to log entries based on a request header:
+
+```ruby
+GovukJsonLogging.configure do
+  add_custom_fields do |fields|
+    fields[:govuk_custom_field] = request.headers["GOVUK-Custom-Header"]
+  end
+end
+```
 
 ## Content Security Policy generation
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.6.0".freeze
+  VERSION = "9.7.0".freeze
 end


### PR DESCRIPTION
I.e. allow apps to add their own custom fields in addition to those that
`GovukJsonLogging` already adds.

It looks like `LogStasher.add_custom_fields` can only be called one
time, otherwise subsequent calls overwrite previous ones.

We found this [happening in the wild in the Content Store app](https://github.com/alphagov/content-store/blob/v33/config/initializers/logstasher.rb#L2), where
`govuk_request_id` et al were missing from the Rails framework logs but
present whenever the logger had been invoked directly from our own code.

This approach does solve the problem for Content Store (along with a
change to Content Store to actually use this option), but I'm keen to hear
suggestions of alternatives.

(https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli)