### PR TITLE
Allow YouTube thumbnails from https://i.ytimg.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.6.0
+
+* Allow YouTube thumbnails from https://i.ytimg.com in the global Content Security Policy ([#328](https://github.com/alphagov/govuk_app_config/pull/328))
+
 # 9.5.0
 
 * Allow gov.uk domains to embed pages in the global Content Security Policy ([#325](https://github.com/alphagov/govuk_app_config/pull/325))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -41,7 +41,8 @@ module GovukContentSecurityPolicy
                    # Some content still links to an old domain we used to use
                    "assets.digital.cabinet-office.gov.uk",
                    # Allow YouTube thumbnails
-                   "https://img.youtube.com"
+                   "https://img.youtube.com",
+                   "https://i.ytimg.com"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.5.0".freeze
+  VERSION = "9.6.0".freeze
 end


### PR DESCRIPTION
It was not added initially to the global Content Security Policy as it was not needed for YouTube thumbnails on image cards, however is used for videos themselves within publications body.

For example:
https://www.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions/car-show-me-tell-me-vehicle-safety-questions