### PR TITLE
Add GOVUK domains to script src CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.8.0
+
+* Add GOVUK domains to script src CSP ([#334](https://github.com/alphagov/govuk_app_config/pull/334))
+
 # 9.7.0
 
 * Enable adding custom LogStasher fields from apps ([#327](https://github.com/alphagov/govuk_app_config/pull/327))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -51,6 +51,7 @@ module GovukContentSecurityPolicy
     policy.script_src :self,
                       *GOOGLE_ANALYTICS_DOMAINS,
                       *GOOGLE_STATIC_DOMAINS,
+                      *GOVUK_DOMAINS,
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
                       "*.ytimg.com",
                       "www.youtube.com",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.7.0".freeze
+  VERSION = "9.8.0".freeze
 end


### PR DESCRIPTION
The `assets.publishing.service.gov.uk` domain can't POST to the feedback form without this, so users can't report problems with our CSV preview pages.