### PR TITLE
Revert "Add GOVUK domains to script src CSP"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.8.1
+
+* Revert "Add GOVUK domains to script src CSP" ([#336](https://github.com/alphagov/govuk_app_config/pull/336))
+
 # 9.8.0
 
 * Add GOVUK domains to script src CSP ([#334](https://github.com/alphagov/govuk_app_config/pull/334))

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -51,7 +51,6 @@ module GovukContentSecurityPolicy
     policy.script_src :self,
                       *GOOGLE_ANALYTICS_DOMAINS,
                       *GOOGLE_STATIC_DOMAINS,
-                      *GOVUK_DOMAINS,
                       # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
                       "*.ytimg.com",
                       "www.youtube.com",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.8.0".freeze
+  VERSION = "9.8.1".freeze
 end


### PR DESCRIPTION
This reverts commit b30410cbfd7c72cec77e6580e13147ed55d535be.

We thought it would solve a CORS issue, but it did not so we don't need this change.