### PR TITLE
Create .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,10 @@
+api_version: 1
+auto_merge:
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
Allow internal GDS dependencies to be auto-merged.

https://trello.com/c/tUU1YoaS/3387-enable-auto-merging-on-remaining-psr-repos