### PR TITLE
Use shorthand lambda syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
+Style/Lambda:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ and occurs at the time of a data sync, then it will be excluded even if the cust
 
 ```ruby
 GovukError.configure do |config|
-  config.before_send = lambda do |event, hint|
+  config.before_send = ->(event, hint) {
     hint[:exception].is_a?(ErrorWeWantToIgnore) ? nil : event
-  end
+  }
 end
 ```
 


### PR DESCRIPTION
Fixes #341

`SimpleDelegator` was intercepting the `lambda` call via `method_missing`, and delegating to `Kernel#lambda`, passing the given block. This explodes on Ruby 3.3 because `lambda` only accepts block literals now.

Replacing the `lambda` call with this shorthand syntax sidesteps the issue. RuboCop is unhappy because it prefers the old syntax for multiline lambdas, so I've had to disable that cop.

Tested locally against Content Data Admin.