### PR TITLE
Bump gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-# Unreleased
+# 9.9.0
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
-* Add support for Ruby 3.3.
 
 # 9.8.2
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.8.2".freeze
+  VERSION = "9.9.0".freeze
 end


### PR DESCRIPTION
Dropping support for a Ruby version should be a minor bump according to https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility