### PR TITLE
Add single cookie consent api URLs

### DIFF
--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -71,7 +71,9 @@ module GovukContentSecurityPolicy
                        *GOVUK_DOMAINS,
                        *GOOGLE_ANALYTICS_DOMAINS,
                        # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
-                       "lux.speedcurve.com"
+                       "lux.speedcurve.com",
+                       "gds-single-consent-staging.app",
+                       "gds-single-consent.app"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #


### PR DESCRIPTION
## What / why
Adds the URLs for the single cookie consent API into the CSP. Once the single consent API is enabled on GOV.UK the JS will be making XMLHttprequests to the staging and production environments for the single consent api, so these URLs need to be added to the CSP.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api
