### PR TITLE
9.10.0: Always initialise GovukPrometheusExporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.10.0
+
+* Simplify the logic for deciding whether to initialize `GovukPrometheusExporter`. `GovukPrometheusExporter` provides the `/metrics` webserver and "exporter" process for aggregating counters in multi-process apps. govuk_app_config will now always attempt to initialize GovukPrometheusExporter except when running under `rails console`. The `GOVUK_PROMETHEUS_EXPORTER` environment variable no longer has any effect.
+
 # 9.9.2
 
 * Add single cookie consent api URLs ([#355](https://github.com/alphagov/govuk_app_config/pull/355))


### PR DESCRIPTION
Some client apps have started to assume that the Prometheus "exporter" process (i.e. the process that aggregates counters in multi-process apps) is always available, including in tests.

Now that we handle the case where the `/metrics` port is already taken, there's really no reason not to initialise GovukPrometheusExporter.

Remove the confusing heuristics in `GovukPrometheusExporter.should_configure` and just always attempt to initialise unless we're running under `rails console`. When the init fails, we just print a warning and continue anyway, so this should be a net win for robustness.

If we find edge cases where this still needs to be configurable then I propose we address those if/when we find and understand them. I expect we won't need to, though.

Kudos to @leenagupte for reporting the issue.