### PR TITLE
Add GDS::SSO::PermissionDeniedError to excluded exceptions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.11.0
+
+* Add GDS::SSO::PermissionDeniedError to excluded exceptions list ([#366](https://github.com/alphagov/govuk_app_config/pull/366))
+
 # 9.10.0
 
 * Simplify the logic for deciding whether to initialize `GovukPrometheusExporter`. `GovukPrometheusExporter` provides the `/metrics` webserver and "exporter" process for aggregating counters in multi-process apps. govuk_app_config will now always attempt to initialize GovukPrometheusExporter except when running under `rails console`. The `GOVUK_PROMETHEUS_EXPORTER` environment variable no longer has any effect.

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -40,6 +40,7 @@ module GovukError
         "CGI::Session::CookieStore::TamperedWithCookie",
         "GdsApi::HTTPIntermittentServerError",
         "GdsApi::TimedOutException",
+        "GDS::SSO::PermissionDeniedError",
         "Mongoid::Errors::DocumentNotFound",
         "Puma::HttpParserError",
         "Sinatra::NotFound",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.10.0".freeze
+  VERSION = "9.11.0".freeze
 end


### PR DESCRIPTION
Related to: https://github.com/alphagov/gds-sso/pull/300

-  We do not need to capture these errors generated from gds-sso. They do not indicate that something went wrong with the application; rather, they indicate that a user does not have permissions to access a resource.

trello card: https://trello.com/c/qb1qpwnr/1369-additional-functionality-to-gds-sso-gem-for-intercepting-401s-and-providing-a-route-constraint