### PR TITLE
Add new 'NonGovukDomains' module with 'EXTERNAL_HOST_REDIRECT_ALLOW_LIST' constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.12.0
+
+* Add new `NonGovukDomains` module with `EXTERNAL_HOST_REDIRECT_ALLOW_LIST` constant, so that we can avoid duplicating allowlists across publishing apps. ([#367](https://github.com/alphagov/govuk_app_config/pull/367))
+
 # 9.11.0
 
 * Add GDS::SSO::PermissionDeniedError to excluded exceptions list ([#366](https://github.com/alphagov/govuk_app_config/pull/366))

--- a/lib/govuk_app_config/non_govuk_domains.rb
+++ b/lib/govuk_app_config/non_govuk_domains.rb
@@ -1,0 +1,12 @@
+module NonGovukDomains
+  EXTERNAL_HOST_REDIRECT_ALLOW_LIST = %w[
+    .caa.co.uk
+    .gov.uk
+    .judiciary.uk
+    .moneyhelper.org.uk
+    .nationalhighways.co.uk
+    .nhs.uk
+    .police.uk
+    .ukri.org
+  ].freeze
+end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.11.0".freeze
+  VERSION = "9.12.0".freeze
 end


### PR DESCRIPTION
Currently, we have to try to keep three different allowlists in
sync:

- https://github.com/alphagov/whitehall/blob/b3ce66d717e8a78a2f59a3fce36f271359ab09e1/app/validators/gov_uk_url_format_validator.rb#L3-L11
- https://github.com/alphagov/short-url-manager/blob/d11edaa002b7c37eb7b3e45c1c289d99443eceef/app/models/concerns/short_url_validations.rb#L4-L15
- https://github.com/alphagov/publishing-api/blob/c82ab015b0751803302e352fc19deb23630daa7d/app/validators/routes_and_redirects_validator.rb#L2-L11

If the lists fall out of sync, we risk being inconsistent in which
domains we allow redirects to, and potentially a data integrity
issue whereby a publishing app might think a redirect is fine,
but it's ultimately rejected in Publishing API.

This PR copies over the current iteration of allowed redirect
domains (which have been double-checked with Policy and Strategy
in https://gds.slack.com/archives/CADTL63QR/p1714556082803429).

When this is released, we can then update the publishing apps to
refer to this shared allowlist instead.