### PR TITLE
Prevent old logstasher monkey patch from overriding patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.11.2
 
 * Fix Logstasher monkey patch overriding patch from this library for OpenTelemetry errors ([#377](https://github.com/alphagov/govuk_app_config/pull/377))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix Logstasher monkey patch overriding patch from this library for OpenTelemetry errors ([#377](https://github.com/alphagov/govuk_app_config/pull/377))
+
 # 9.11.1
 
 * Fix OpenTelemetry errors when using with Logstasher gem ([#372](https://github.com/alphagov/govuk_app_config/pull/372))

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -20,6 +20,8 @@ module GovukJsonLogging
     config = Rails.application.config.logstasher
     if (!config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true
       require_relative "./govuk_json_logging/rails_ext/action_controller/metal/instrumentation"
+      # Prevent the old monkey patch being applied
+      config.controller_monkey_patch = false
     end
 
     configuration = Configuration.new

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.11.1".freeze
+  VERSION = "9.11.2".freeze
 end


### PR DESCRIPTION
For some apps the initialisation order means that the logstasher is initialiser after and therefore the original patch is applied after the patch from this library, effectively disabling the fix for [OpenTelementry traces](https://github.com/alphagov/govuk_app_config/pull/372).

This sets the config option to prevent the logstasher from applying its patch after, if the original patch is already applied.