### PR TITLE
Set time_zone to London in all GOV.UK apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Adds the basics of a GOV.UK application:
 - Statsd client for reporting stats (deprecated; use Prometheus instead)
 - Rails logging
 - Content Security Policy generation for frontend apps
+- Sets the time zone to London
 
 ## Installation
 
@@ -181,6 +182,9 @@ GovukContentSecurityPolicy.configure
 
 Some frontend apps support languages that are not defined in the i18n gem. This provides them with our own custom rules for these languages.
 
+## Time zone
+
+This gem sets `config.time_zone` to `"London"` - this cannot currently be overridden in application config.
 
 ## License
 

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -9,5 +9,6 @@ require "govuk_app_config/govuk_prometheus_exporter"
 if defined?(Rails)
   require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_content_security_policy"
+  require "govuk_app_config/govuk_timezone"
   require "govuk_app_config/railtie"
 end

--- a/lib/govuk_app_config/govuk_timezone.rb
+++ b/lib/govuk_app_config/govuk_timezone.rb
@@ -1,0 +1,5 @@
+module GovukTimezone
+  def self.configure(config)
+    config.time_zone = "London"
+  end
+end

--- a/lib/govuk_app_config/govuk_timezone.rb
+++ b/lib/govuk_app_config/govuk_timezone.rb
@@ -1,5 +1,14 @@
 module GovukTimezone
   def self.configure(config)
+    case config.time_zone
+    when "UTC"
+      Rails.logger.info "govuk_app_config changing time_zone from UTC (the default) to London"
+    when "London"
+      Rails.logger.info "govuk_app_config always sets time_zone to London - there is no need to set config.time_zone in your app"
+    else
+      raise "govuk_app_config prevents configuring time_zones other than London - config.time_zone was set to #{config.time_zone}"
+    end
+
     config.time_zone = "London"
   end
 end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -14,6 +14,10 @@ module GovukAppConfig
       end
     end
 
+    initializer "govuk_app_config.configure_timezone", before: "active_support.initialize_time_zone" do |app|
+      GovukTimezone.configure(app.config)
+    end
+
     config.before_initialize do
       GovukJsonLogging.configure if ENV["GOVUK_RAILS_JSON_LOGGING"]
     end

--- a/spec/lib/govuk_timezone_spec.rb
+++ b/spec/lib/govuk_timezone_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+require "govuk_app_config/govuk_timezone"
+
+RSpec.describe GovukError do
+  describe ".configure" do
+    it "should set time_zone to London" do
+      config = double(:config)
+      expect(config).to receive(:time_zone=).with("London")
+      GovukTimezone.configure(config)
+    end
+  end
+end

--- a/spec/lib/govuk_timezone_spec.rb
+++ b/spec/lib/govuk_timezone_spec.rb
@@ -3,10 +3,30 @@ require "govuk_app_config/govuk_timezone"
 
 RSpec.describe GovukError do
   describe ".configure" do
-    it "should set time_zone to London" do
-      config = double(:config)
-      expect(config).to receive(:time_zone=).with("London")
+    let(:config) { Rails::Railtie::Configuration.new }
+    let(:logger) { instance_double("ActiveSupport::Logger") }
+
+    before do
+      allow(Rails).to receive(:logger).and_return(logger)
+    end
+
+    it "should override the default UTC time_zone to London" do
+      config.time_zone = "UTC"
+      expect(logger).to receive(:info)
       GovukTimezone.configure(config)
+      expect(config.time_zone).to eq("London")
+    end
+
+    it "should leave time_zones set to London as London" do
+      config.time_zone = "London"
+      expect(logger).to receive(:info)
+      GovukTimezone.configure(config)
+      expect(config.time_zone).to eq("London")
+    end
+
+    it "should raise an error if configured with any other time zone" do
+      config.time_zone = "Shanghai"
+      expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zones/)
     end
   end
 end


### PR DESCRIPTION
Our conventions for rails apps say that we should set time_zone to London:

https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html#specify-london-as-the-timezone

In practice however, only about half of the apps do so. Based on the apps running in integration:

Apps which set the time_zone to London:

    AccountApi
    Collections
    CollectionsPublisher
    ContentPublisher
    Collections
    Frontend
    GovernmentFrontend
    Static
    EmailAlertApi
    Frontend
    GovernmentFrontend
    GovukChat
    LocationsApi
    Maslow
    PlacesManager
    Publisher
    ReleaseApp
    SearchApiV2
    Signon
    SmartAnswers
    SpecialistPublisher
    Static
    Whitehall

Apps which leave the time_zone as it's default UTC:

    AuthenticatingProxy
    Contacts
    ContentDataAdmin
    ContentPerformanceManager
    ContentStore
    ContentTagger
    ContentStore
    RouterApi
    EmailAlertFrontend
    Feedback
    FinderFrontend
    HmrcManualsApi
    LinkCheckerApi
    LocalLinksManager
    ManualsPublisher
    RouterApi
    SearchAdmin
    SearchV2Evaluator
    ServiceManualPublisher
    ShortUrlManager
    Support
    SupportApi
    Transition
    TravelAdvicePublisher

Having the apps use inconsistent time_zones feels like a recipe for trouble.

`config.time_zone` has to be set before `active_support.initialize_time_zone` runs, so we specify that our initializer must run before it. Unfortunately this means that there's no way for applications to set their own value of `time_zone`. I think this is probably desirable for consumers of `govuk_app_config` though - I can't think of a legitimate reason why we'd want some apps using different time zones.

Technically this is a breaking change, as it could change behaviour in apps which are using timezone-specific methods and expecting to get UTC times out. Hopefully we're already explicit about when we want UTC and when we want local time though.

Once this is merged, I'll remove the bit in the docs about setting time_zone, as it will be automatic.

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️
