### PR TITLE
Cut release for London Time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.12.0
+
+* Set time_zone to London in all GOV.UK apps ([#381](https://github.com/alphagov/govuk_app_config/pull/381))
+
 # 9.11.2
 
 * Fix Logstasher monkey patch overriding patch from this library for OpenTelemetry errors ([#377](https://github.com/alphagov/govuk_app_config/pull/377))

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.11.2".freeze
+  VERSION = "9.12.0".freeze
 end


### PR DESCRIPTION
I've made this a minor version, even though it's technically a breaking change (or at least, updating will result in a change in behaviour).

I'm pretty confident that the new behaviour (London time_zone instead of UTC) is correct for all GOV.UK apps, so they shouldn't need to think about this as a "breaking" change.
