### PR TITLE
Exclude Slimmer::SourceWrapperNotFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.13.0
 
 * Add Slimmer::SourceWrapperNotFoundError to excluded exceptions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add Slimmer::SourceWrapperNotFoundError to excluded exceptions.
+
 # 9.12.0
 
 * Set time_zone to London in all GOV.UK apps ([#381](https://github.com/alphagov/govuk_app_config/pull/381))

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -45,6 +45,7 @@ module GovukError
         "Puma::HttpParserError",
         "Sinatra::NotFound",
         "Slimmer::IntermittentRetrievalError",
+        "Slimmer::SourceWrapperNotFoundError",
         "Sidekiq::JobRetry::Skip",
         "SignalException",
       ]

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.12.0".freeze
+  VERSION = "9.13.0".freeze
 end


### PR DESCRIPTION
⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.

## What

We keep getting the following exception in production: https://govuk.sentry.io/issues/4958108827/?environment=production&environment=production-eks&environment=producton&project=-1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=9

After [the discussion](https://gds.slack.com/archives/C052X8S2P8A/p1718796354165479) there was a suggestion to keep the SourceWrapperNotFoundError instead of reverting the PRs introducing it. The error should not be sent to Sentry, but developers should still receive it in their local environments and in the tests.

There is a separate, related [PR](https://github.com/alphagov/slimmer/pull/334) applying changes to slimmer.

## Why

[Trello ticket](https://trello.com/c/iyPxdU09/2495-sentry-errors-investigate-fix-frontend-nomethoderror)