### PR TITLE
Really release v9.13.1

### DIFF
--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.13.0".freeze
+  VERSION = "9.13.1".freeze
 end


### PR DESCRIPTION
The auto-release workflow is not working as expected https://github.com/alphagov/govuk_app_config/pull/386/files

---

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
