### PR TITLE
Configure time_zone with govuk_time_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.14.0
+
+* Configure `time_zone` with `govuk_time_zone` [#392](https://github.com/alphagov/govuk_app_config/pull/392)
+
 # 9.13.1
 
 * Update dependencies

--- a/README.md
+++ b/README.md
@@ -184,7 +184,17 @@ Some frontend apps support languages that are not defined in the i18n gem. This 
 
 ## Time zone
 
-This gem sets `config.time_zone` to `"London"` - this cannot currently be overridden in application config.
+This gem sets `config.time_zone` to `"London"` by default.
+
+If you require a different time zone, you can set it with `config.govuk_time_zone`:
+
+```ruby
+config.govuk_time_zone = "UTC"
+```
+
+Note that we've introduced a new config field (`govuk_time_zone`) here, because
+it's otherwise not possible to distinguish between an app using UTC as the
+default and an app explicitly asking for UTC.
 
 ## License
 

--- a/lib/govuk_app_config/govuk_timezone.rb
+++ b/lib/govuk_app_config/govuk_timezone.rb
@@ -1,14 +1,12 @@
 module GovukTimezone
   def self.configure(config)
-    case config.time_zone
-    when "UTC"
-      Rails.logger.info "govuk_app_config changing time_zone from UTC (the default) to London"
-    when "London"
-      Rails.logger.info "govuk_app_config always sets time_zone to London - there is no need to set config.time_zone in your app"
-    else
-      raise "govuk_app_config prevents configuring time_zones other than London - config.time_zone was set to #{config.time_zone}"
-    end
+    raise "govuk_app_config prevents configuring time_zone with config.time_zone - use config.govuk_time_zone instead" unless config.time_zone == "UTC"
 
-    config.time_zone = "London"
+    if config.respond_to? :govuk_time_zone
+      config.time_zone = config.govuk_time_zone
+    else
+      Rails.logger.info 'govuk_app_config changing time_zone from UTC (the rails default) to London (the GOV.UK default). Set config.govuk_time_zone = "UTC" if you need UTC.'
+      config.time_zone = "London"
+    end
   end
 end

--- a/lib/govuk_app_config/govuk_timezone.rb
+++ b/lib/govuk_app_config/govuk_timezone.rb
@@ -2,7 +2,7 @@ module GovukTimezone
   def self.configure(config)
     raise "govuk_app_config prevents configuring time_zone with config.time_zone - use config.govuk_time_zone instead" unless config.time_zone == "UTC"
 
-    if config.respond_to? :govuk_time_zone
+    if config.respond_to?(:govuk_time_zone) && config.govuk_time_zone.present?
       config.time_zone = config.govuk_time_zone
     else
       Rails.logger.info 'govuk_app_config changing time_zone from UTC (the rails default) to London (the GOV.UK default). Set config.govuk_time_zone = "UTC" if you need UTC.'

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.13.1".freeze
+  VERSION = "9.14.0".freeze
 end

--- a/spec/lib/govuk_timezone_spec.rb
+++ b/spec/lib/govuk_timezone_spec.rb
@@ -3,7 +3,6 @@ require "govuk_app_config/govuk_timezone"
 
 RSpec.describe GovukError do
   describe ".configure" do
-    let(:config) { Rails::Railtie::Configuration.new }
     let(:logger) { instance_double("ActiveSupport::Logger") }
 
     before do
@@ -11,22 +10,23 @@ RSpec.describe GovukError do
     end
 
     it "should override the default UTC time_zone to London" do
-      config.time_zone = "UTC"
+      config = Struct.new(:time_zone).new("UTC")
       expect(logger).to receive(:info)
       GovukTimezone.configure(config)
       expect(config.time_zone).to eq("London")
     end
 
-    it "should leave time_zones set to London as London" do
-      config.time_zone = "London"
-      expect(logger).to receive(:info)
+    it "should allow apps to set time_zone explicitly with config.govuk_time_zone" do
+      config = Struct.new(:time_zone, :govuk_time_zone).new("UTC", "Shanghai")
       GovukTimezone.configure(config)
-      expect(config.time_zone).to eq("London")
+      expect(config.time_zone).to eq("Shanghai")
     end
 
-    it "should raise an error if configured with any other time zone" do
-      config.time_zone = "Shanghai"
-      expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zones/)
+    it "should raise an error if config.time_zone is set to anything other than the default UTC" do
+      config = Struct.new(:time_zone).new("London")
+      expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zone with config[.]time_zone/)
+      config = Struct.new(:time_zone).new("Shanghai")
+      expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zone with config[.]time_zone/)
     end
   end
 end

--- a/spec/lib/govuk_timezone_spec.rb
+++ b/spec/lib/govuk_timezone_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe GovukError do
       expect(config.time_zone).to eq("Shanghai")
     end
 
+    it "should default to London if config.govuk_time_zone is nil" do
+      config = Struct.new(:time_zone, :govuk_time_zone).new("UTC", nil)
+      expect(logger).to receive(:info)
+      GovukTimezone.configure(config)
+      expect(config.time_zone).to eq("London")
+    end
+
     it "should raise an error if config.time_zone is set to anything other than the default UTC" do
       config = Struct.new(:time_zone).new("London")
       expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zone with config[.]time_zone/)

--- a/spec/lib/govuk_timezone_spec.rb
+++ b/spec/lib/govuk_timezone_spec.rb
@@ -1,8 +1,10 @@
+require "ostruct"
 require "spec_helper"
 require "govuk_app_config/govuk_timezone"
 
 RSpec.describe GovukError do
   describe ".configure" do
+    let(:config) { OpenStruct.new }
     let(:logger) { instance_double("ActiveSupport::Logger") }
 
     before do
@@ -10,29 +12,31 @@ RSpec.describe GovukError do
     end
 
     it "should override the default UTC time_zone to London" do
-      config = Struct.new(:time_zone).new("UTC")
+      config.time_zone = "UTC"
       expect(logger).to receive(:info)
       GovukTimezone.configure(config)
       expect(config.time_zone).to eq("London")
     end
 
     it "should allow apps to set time_zone explicitly with config.govuk_time_zone" do
-      config = Struct.new(:time_zone, :govuk_time_zone).new("UTC", "Shanghai")
+      config.time_zone = "UTC"
+      config.govuk_time_zone = "Shanghai"
       GovukTimezone.configure(config)
       expect(config.time_zone).to eq("Shanghai")
     end
 
     it "should default to London if config.govuk_time_zone is nil" do
-      config = Struct.new(:time_zone, :govuk_time_zone).new("UTC", nil)
+      config.time_zone = "UTC"
+      config.govuk_time_zone = nil
       expect(logger).to receive(:info)
       GovukTimezone.configure(config)
       expect(config.time_zone).to eq("London")
     end
 
     it "should raise an error if config.time_zone is set to anything other than the default UTC" do
-      config = Struct.new(:time_zone).new("London")
+      config.time_zone = "London"
       expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zone with config[.]time_zone/)
-      config = Struct.new(:time_zone).new("Shanghai")
+      config.time_zone = "Shanghai"
       expect { GovukTimezone.configure(config) }.to raise_error(/govuk_app_config prevents configuring time_zone with config[.]time_zone/)
     end
   end


### PR DESCRIPTION
In the original implementation of the GovukTimezone module we assumed that literally all GOV.UK apps would use the London timezone. We didn't really consider how to make it easy for apps to override this if needed.

Since then, we've found a couple of examples where apps genuinely do want to override the timezone:

- publishing-api, which always wants to present dates as UTC because its an API
- travel-advice-publisher, which always wants to present dates as UTC because a majority of its users are in non-London timezones (so BST is confusing)

Currently, these apps override GovukTimezone by inserting an initializer between it and active_support.initialize_time_zone like this:

    initializer "publishing_api.configure_timezone",
                after: "govuk_app_config.configure_timezone",
                before: "active_support.initialize_time_zone" do
      config.time_zone = "UTC"
    end

    # https://github.com/alphagov/publishing-api/blob/252f47a1/config/application.rb#L123-L129

This is a bit of a faff, and it also results in some very confusing logs.

Because the GovukTimezone still runs in this setup, it would log "govuk_app_config changing time_zone from UTC (the default) to London" ... but then we'd set it back to UTC without logging anything, making it seem from the logs that the time_zone was London when it was actually UTC. Bleurgh.

Unfortunately, it's not possible to work out just from config.time_zone whether the time_zone is set to UTC because its the default (in which case we should override it to London), or because the app has explicitly set it (in which case we should leave it alone).

I think the best approach is to introduce a new method govuk_time_zone, which won't be set by default to allow us to distinguish these scenarios.

This has the nice benefit that we can be a bit more strict about what's an error case and what just requires a log message.

If config.time_zone is set to anything other than UTC, that's an error. If config.govuk_time_zone is set, we use that, otherwise we override UTC to London and log a message.

This will be slightly annoying to release, because we'll have to remove all the instances of config.time_zone = "London" across our apps. If we want to be explicit, we can set config.govuk_time_zone. If we're happy with the default, then we can just remove the line.

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️
