### PR TITLE
Update SidekiqRedis healthcheck to work with Sidekiq 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.14.3
+
+* Update SidekiqRedis healthcheck to work with Sidekiq 7 [#399](https://github.com/alphagov/govuk_app_config/pull/399)
+
 # 9.14.2
 
 * Update dependencies

--- a/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/sidekiq_redis.rb
@@ -5,7 +5,14 @@ module GovukHealthcheck
     end
 
     def status
-      Sidekiq.redis_info ? OK : CRITICAL
+      # Sidekiq 7 introduced a default_configuration object which has .redis_info
+      # for querying Redis information. If the default_configuration object isn't present,
+      # we can fall back to the old method of querying it using 'Sidekiq.redis_info'.
+      if Sidekiq.respond_to?(:default_configuration)
+        Sidekiq.default_configuration.redis_info ? OK : CRITICAL
+      else
+        Sidekiq.redis_info ? OK : CRITICAL
+      end
     rescue StandardError
       # One would expect a Redis::BaseConnectionError, but this should be
       # critical if any exception is raised when making a call to redis.

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.14.2".freeze
+  VERSION = "9.14.3".freeze
 end


### PR DESCRIPTION
This healthcheck has been failing for applications that have upgraded to Sidekiq 7. Sidekiq 7 uses `redis-client`' which has a different API to `redis` which was used in Sidekiq 6.

To access `redis_info` you now have to call

```
Sidekiq.default_configration.redis_info
```

while in Sidekiq 6 you call

```
Sidekiq.redis_info
```

This updates the healthcheck to work with both versions of Sidekiq checking if`Sidekiq responds to `.redis_info`.

If it does it calls that, otherwise it calls `Sidekiq.default_configration.redis_info`.

It's not massively clear these healthchecks are actually being used for anything since this has been failing on production applications for a couple of weeks without anyone noticing.

We're in the process of speaking to the platform team to see if they're actually being used for anything and if not whether they should be removed.

But for now i'm just updating it to work with Sidekiq 7.

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
