### PR TITLE
Add Sanitiser::Strategy::SanitisingError to the list of excluded errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add Sanitiser::Strategy::SanitisingError to excluded exceptions list ([#402](https://github.com/alphagov/govuk_app_config/pull/402))
+
 # 9.14.6
 
 * Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.15.0
 
 * Add Sanitiser::Strategy::SanitisingError to excluded exceptions list ([#402](https://github.com/alphagov/govuk_app_config/pull/402))
 

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -47,6 +47,7 @@ module GovukError
         "Slimmer::IntermittentRetrievalError",
         "Slimmer::SourceWrapperNotFoundError",
         "Sidekiq::JobRetry::Skip",
+        "Sanitiser::Strategy::SanitisingError",
         "SignalException",
       ]
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.14.6".freeze
+  VERSION = "9.15.0".freeze
 end


### PR DESCRIPTION
⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.

## What

Do not send Sanitiser::Strategy::SanitisingError to Sentry. This error should still be raised in all environments.

This error is raised in some apps when an incorrect (wrong UTF-8 encoding) character is encountered in a query string or in a cookie.

## Why

[Trello card](https://trello.com/c/FeOwxE2x/2938-silently-handle-invalid-byte-sequence-in-utf-8-errors-l)