### PR TITLE
GovukPrometheus - custom labels from rack env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.16.0
+
+* GovukPrometheus - custom labels from rack env ([#424](https://github.com/alphagov/govuk_app_config/pull/424))
+
 # 9.15.8
 
 * Update dependencies

--- a/lib/govuk_app_config/govuk_prometheus_exporter.rb
+++ b/lib/govuk_app_config/govuk_prometheus_exporter.rb
@@ -4,13 +4,13 @@ require "prometheus_exporter/server"
 require "prometheus_exporter/middleware"
 
 module GovukPrometheusExporter
-  #
-  # See https://github.com/discourse/prometheus_exporter/pull/293
-  #
-  # RailsMiddleware can be removed and replaced with the default middleware if
-  # that PR is merged / released
-  #
   class RailsMiddleware < PrometheusExporter::Middleware
+    #
+    # See https://github.com/discourse/prometheus_exporter/pull/293
+    #
+    # default_labels can be removed and fall through to the base method if
+    # that PR is merged / released
+    #
     def default_labels(env, _result)
       controller_instance = env["action_controller.instance"]
       action = controller = nil
@@ -28,6 +28,10 @@ module GovukPrometheusExporter
         controller: controller || "other",
       }
     end
+
+    def custom_labels(env)
+      env.fetch("govuk.prometheus_labels", {})
+    end
   end
 
   class SinatraMiddleware < PrometheusExporter::Middleware
@@ -38,6 +42,10 @@ module GovukPrometheusExporter
       # cardinality.  For now, just accept that we can't be more specific than
       # the application / pod and don't provide any other labels
       {}
+    end
+
+    def custom_labels(env)
+      env.fetch("govuk.prometheus_labels", {})
     end
   end
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.15.8".freeze
+  VERSION = "9.16.0".freeze
 end


### PR DESCRIPTION
Apps can use request.env['govuk.prometheus_labels'] to specify custom labels for prometheus.

For example, and app might do:

    prometheus_labels = request.env.fetch('govuk.prometheus_labels', {})
    request.env['govuk.prometheus_labels'] = prometheus_labels.merge(
      document_type: @content_item.document_type,
      schema_name: @content_item.schema_name,
    )

To set the document type / schema name as custom labels (which is useful for the apps where this isn't obvious based on controller / action, like government-frontend)

Testing locally, this results in metrics like:

    http_request_duration_seconds_count{action="show",controller="content_items",document_type="answer",schema_name="answer"} 1

Care does need to be taken with the cardinality of prometheus labels (i.e. there shouldn't be too many different combinations of labels), but things like document_type are useful and shouldn't increase cardinality too much.
