### PR TITLE
Add support for internationalisation of Rails framework strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.17.0
+
+* Add support for internationalisation of Rails framework strings ([#444](https://github.com/alphagov/govuk_app_config/pull/444))
+
 # 9.16.11
 
 * Update dependencies

--- a/README.md
+++ b/README.md
@@ -178,9 +178,19 @@ app with the following content:
 GovukContentSecurityPolicy.configure
 ```
 
-## Internationalisation rules
+## Internationalisation
 
-Some frontend apps support languages that are not defined in the i18n gem. This provides them with our own custom rules for these languages.
+Some frontend apps support languages that are not yet defined in the [rails-i18n](https://github.com/svenfuchs/rails-i18n) gem that is bundled with Rails.
+
+The missing translations can be added to a locale file in the folder [`lib/govuk_app_config/govuk_i8n`](lib/govuk_app_config/govuk_i18n/). The [`:en`](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-GB.yml) locale file in the Rails repo  can be used as a guide to key names, as it contains all the keys that Rails uses for a fully internationalised language. It is not necessary to add all of these keys to your file.
+
+See [example.yml](lib/govuk_app_config/govuk_i18n/docs/example.yml) for the most likely structure.
+
+The translations can be enabled in the frontend application by creating a file at `config/initializers/govuk_i18n.rb` with the following content:
+
+```ruby
+GovukI18n.configure
+```
 
 ## Time zone
 

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -8,6 +8,7 @@ require "govuk_app_config/version"
 
 if defined?(Rails)
   require "govuk_app_config/govuk_content_security_policy"
+  require "govuk_app_config/govuk_i18n"
   require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_timezone"
   require "govuk_app_config/railtie"

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -1,14 +1,14 @@
-require "govuk_app_config/version"
-require "govuk_app_config/govuk_statsd"
 require "govuk_app_config/govuk_error"
-require "govuk_app_config/govuk_proxy/static_proxy"
 require "govuk_app_config/govuk_healthcheck"
 require "govuk_app_config/govuk_open_telemetry"
 require "govuk_app_config/govuk_prometheus_exporter"
+require "govuk_app_config/govuk_proxy/static_proxy"
+require "govuk_app_config/govuk_statsd"
+require "govuk_app_config/version"
 
 if defined?(Rails)
-  require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_content_security_policy"
+  require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_timezone"
   require "govuk_app_config/railtie"
 end

--- a/lib/govuk_app_config/govuk_i18n.rb
+++ b/lib/govuk_app_config/govuk_i18n.rb
@@ -1,0 +1,7 @@
+module GovukI18n
+  GOVUK_APP_CONFIG_PATH = Gem.loaded_specs["govuk_app_config"].gem_dir
+
+  def self.configure
+    I18n.load_path += Dir[File.join(GOVUK_APP_CONFIG_PATH, "lib", "govuk_app_config", "govuk_i18n", "*.{yml}").to_s]
+  end
+end

--- a/lib/govuk_app_config/govuk_i18n/docs/example.yml
+++ b/lib/govuk_app_config/govuk_i18n/docs/example.yml
@@ -1,0 +1,113 @@
+## Example locale file structure
+---
+#  example:
+#    date:
+#      abbr_day_names:
+#      - Sun
+#      - Mon
+#      - Tue
+#      - Wed
+#      - Thu
+#      - Fri
+#      - Sat
+#      abbr_month_names:
+#      - Jan
+#      - Feb
+#      - Mar
+#      - Apr
+#      - May
+#      - Jun
+#      - Jul
+#      - Aug
+#      - Sep
+#      - Oct
+#      - Nov
+#      - Dec
+#      day_names:
+#      - Sunday
+#      - Monday
+#      - Tuesday
+#      - Wednesday
+#      - Thursday
+#      - Friday
+#      - Saturday
+#      formats:
+#        default: "%Y-%m-%d"
+#        long: "%B %d, %Y"
+#        short: "%b %d"
+#      month_names:
+#      -
+#      - January
+#      - February
+#      - માર્ચ
+#      - April
+#      - May
+#      - જૂન
+#      - July
+#      - August
+#      - September
+#      - October
+#      - November
+#      - December
+#      order:
+#      - year
+#      - month
+#      - day
+#    datetime:
+#      distance_in_words:
+#        about_x_hours:
+#          one: about %{count} hour
+#          other: about %{count} hours
+#        about_x_months:
+#          one: about %{count} month
+#          other: about %{count} months
+#        about_x_years:
+#          one: about %{count} year
+#          other: about %{count} years
+#        almost_x_years:
+#          one: almost %{count} year
+#          other: almost %{count} years
+#        half_a_minute: half a minute
+#        less_than_x_seconds:
+#          one: less than %{count} second
+#          other: less than %{count} seconds
+#        less_than_x_minutes:
+#          one: less than a minute
+#          other: less than %{count} minutes
+#        over_x_years:
+#          one: over %{count} year
+#          other: over %{count} years
+#        x_seconds:
+#          one: "%{count} second"
+#          other: "%{count} seconds"
+#        x_minutes:
+#          one: "%{count} minute"
+#          other: "%{count} minutes"
+#        x_days:
+#          one: "%{count} day"
+#          other: "%{count} days"
+#        x_months:
+#          one: "%{count} month"
+#          other: "%{count} months"
+#        x_years:
+#          one: "%{count} year"
+#          other: "%{count} years"
+#      prompts:
+#        second: Seconds
+#        minute: Minute
+#        hour: Hour
+#        day: Day
+#        month: Month
+#        year: Year
+#    support:
+#      array:
+#        last_word_connector: ", and "
+#        two_words_connector: " and "
+#        words_connector: ", "
+#    time:
+#      am: am
+#      formats:
+#        default: "%a, %d %b %Y %H:%M:%S %z"
+#        long: "%B %d, %Y %H:%M"
+#        short: "%d %b %H:%M"
+#      pm: pm

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.16.11".freeze
+  VERSION = "9.17.0".freeze
 end

--- a/spec/lib/govuk_i18n_spec.rb
+++ b/spec/lib/govuk_i18n_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "govuk_app_config/govuk_i18n"
+
+RSpec.describe GovukI18n do
+  describe ".configure" do
+    context "locale files exist" do
+      let(:govuk_i18n_locale_path_stubs) { ["/lib/govuk_app_config/govuk_i18n/my_locale.yml", "/lib/govuk_app_config/govuk_i18n/my_other_locale.yml"] }
+
+      before { allow(Dir).to receive(:[]).and_return(govuk_i18n_locale_path_stubs) }
+
+      after { I18n.load_path = nil }
+
+      it "adds govuk_app_config locales files to the i18n loadpath if explicity configured" do
+        GovukI18n.configure
+
+        govuk_i18n_locale_path_stubs.each do |file_path|
+          expect(I18n.load_path).to include(file_path)
+        end
+      end
+
+      it "does not add govuk_app_config translation files to the loadpath by default" do
+        govuk_i18n_locale_path_stubs.each do |file_path|
+          expect(I18n.load_path).not_to include(file_path)
+        end
+      end
+    end
+
+    context "locale files do not exist" do
+      let(:govuk_i18n_locale_path_stubs) { [] }
+
+      before do
+        allow(Dir).to receive(:[]).and_return(govuk_i18n_locale_path_stubs)
+      end
+
+      it "doesn't mind if apps are configured to import translations but there are none available" do
+        expect { GovukI18n.configure }.not_to(change { I18n.load_path })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Govuk_i18n 

Some languages that are supported by GOV.UK are not yet supported by the
Rails framework. (See [audit](https://docs.google.com/spreadsheets/d/1zbpROLIsFz2ef7JYT8qUlptV7Blp1O0aEENj7CM2HJ8/edit?usp=sharing))

This module allows us to patch these translations so that things like days of the week, month names etc are populated. 

|Before|After|
|-|-|
|<img width="414" alt="Screenshot 2025-04-03 at 13 08 48" src="https://github.com/user-attachments/assets/acb93afe-fa9f-43a6-a29c-ba8dc4137d25" />|<img width="450" alt="Screenshot 2025-04-03 at 13 20 47" src="https://github.com/user-attachments/assets/bb46a8a4-1798-4599-bd20-79c9f8d09b30" />|

[Trello](https://trello.com/c/pJYPgL2D/3396-prepare-prs-to-import-rails-translations)

See review app at https://github.com/alphagov/frontend/pull/4743 which relies on the temporary commit. 



⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
