### PR TITLE
Configure CI workflow to handle concurrent releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
         default: main
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   codeql-sast:
     name: CodeQL SAST scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.17.4
+
+* Update CI workflow to handle concurrent releases ([#461](https://github.com/alphagov/govuk_app_config/pull/461))
+
 # 9.17.3
 
 * Update dependencies

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.17.3".freeze
+  VERSION = "9.17.4".freeze
 end


### PR DESCRIPTION
**As a** platform engineer
**I want** our deployment process for our app repos to handle concurrent releases
**so that** we avoid issues with incorrect ordering of releases

https://github.com/alphagov/govuk-infrastructure/issues/2123