### PR TITLE
Fix GovukEnvironment.current feature export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.18.1
+
+* Properly export `GovukEnvironment.current` feature
+
 # 9.18.0
 
 * Add `GovukEnvironment.current` feature

--- a/lib/govuk_app_config.rb
+++ b/lib/govuk_app_config.rb
@@ -8,6 +8,7 @@ require "govuk_app_config/version"
 
 if defined?(Rails)
   require "govuk_app_config/govuk_content_security_policy"
+  require "govuk_app_config/govuk_environment"
   require "govuk_app_config/govuk_i18n"
   require "govuk_app_config/govuk_json_logging"
   require "govuk_app_config/govuk_timezone"

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.18.0".freeze
+  VERSION = "9.18.1".freeze
 end


### PR DESCRIPTION
Seeing `uninitialized constant #<Class:0x0000ffff697b6560>::GovukEnvironment` when trying to use it upstream. Clearly I forgot to pull it into `lib/govuk_app_config.rb` in #488.

---

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
