### PR TITLE
Release v9.19.0: Add an EmergencyBannerRedis health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.19.0
+
+* Add `GovukHealthcheck.EmergencyBannerRedis` healthcheck
+
 # 9.18.1
 
 * Properly export `GovukEnvironment.current` feature

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -29,7 +29,9 @@ Built-in checks you can use include:
 
 - `GovukHealthcheck::RailsCache` - checks that the Rails cache store, such as Memcached, is acessible by writing and reading back a cache entry called "healthcheck-cache".
 
-- `GovukHealthcheck::Redis` - checks that the app can connect to Redis by writing and reading back a cache entry called "healthcheck-cache".
+- `GovukHealthcheck::Redis` - checks that the app can connect to Redis by writing and reading back a cache entry called "healthcheck-&lt;random_hex>".
+
+- `GovukHealthcheck::EmergencyBannerRedis` - checks that the app can connect to the Redis instance which has the emergency banner config by writing and reading back a cache entry called "healthcheck-emergency-banner-&lt;random_hex>".
 
 - `GovukHealthcheck::Mongoid` - checks that the app has a connection to its Mongo database via Mongoid.
 

--- a/lib/govuk_app_config/govuk_healthcheck.rb
+++ b/lib/govuk_app_config/govuk_healthcheck.rb
@@ -1,5 +1,6 @@
 require "govuk_app_config/govuk_healthcheck/checkup"
 require "govuk_app_config/govuk_healthcheck/active_record"
+require "govuk_app_config/govuk_healthcheck/emergency_banner_redis"
 require "govuk_app_config/govuk_healthcheck/mongoid"
 require "govuk_app_config/govuk_healthcheck/rails_cache"
 require "govuk_app_config/govuk_healthcheck/redis"

--- a/lib/govuk_app_config/govuk_healthcheck/emergency_banner_redis.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/emergency_banner_redis.rb
@@ -9,7 +9,7 @@ module GovukHealthcheck
     def status
       client = ::Redis.new(
         url: ENV["EMERGENCY_BANNER_REDIS_URL"],
-        reconnect_attempts: [2, 5, 15], # Purposefully short since this is a healthcheck
+        reconnect_attempts: [0, 0.25], # Purposefully short since this is a healthcheck
       )
 
       key = "healthcheck-emergency-banner-#{SecureRandom.hex}"

--- a/lib/govuk_app_config/govuk_healthcheck/emergency_banner_redis.rb
+++ b/lib/govuk_app_config/govuk_healthcheck/emergency_banner_redis.rb
@@ -1,0 +1,28 @@
+require "securerandom"
+
+module GovukHealthcheck
+  class EmergencyBannerRedis
+    def name
+      :emergency_banner_redis_connectivity
+    end
+
+    def status
+      client = ::Redis.new(
+        url: ENV["EMERGENCY_BANNER_REDIS_URL"],
+        reconnect_attempts: [2, 5, 15], # Purposefully short since this is a healthcheck
+      )
+
+      key = "healthcheck-emergency-banner-#{SecureRandom.hex}"
+
+      client.set(key, "val")
+      client.get(key)
+      client.del(key)
+
+      client.close
+
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.18.1".freeze
+  VERSION = "9.19.0".freeze
 end

--- a/spec/lib/govuk_healthcheck/emergency_banner_redis_spec.rb
+++ b/spec/lib/govuk_healthcheck/emergency_banner_redis_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "govuk_app_config/govuk_healthcheck"
+require_relative "shared_interface"
+
+RSpec.describe GovukHealthcheck::EmergencyBannerRedis do
+  let(:redis) { double(:redis) }
+  let(:redis_client) { double(:redis_client, set: "OK", get: "val", del: 1, close: nil) }
+  let(:redis_url) { "redis://emergency-banner/1" }
+  let(:redis_bad_url) { "redis://BAD_URL/1" }
+  let(:redis_bad_client) { double }
+
+  before do
+    stub_const("Redis", redis)
+    allow(redis).to receive(:new).with(url: redis_url, reconnect_attempts: anything).and_return(redis_client)
+    allow(redis).to receive(:new).with(url: redis_bad_url, reconnect_attempts: anything).and_return(redis_bad_client)
+    allow(redis_bad_client).to receive(:set).and_raise
+    allow(redis_bad_client).to receive(:get).and_raise
+    allow(redis_bad_client).to receive(:del).and_raise
+    allow(redis_bad_client).to receive(:close).and_raise
+    allow(SecureRandom).to receive(:hex).and_return("abc")
+  end
+
+  context "when redis is available" do
+    around(:example) do |example|
+      ClimateControl.modify EMERGENCY_BANNER_REDIS_URL: redis_url do
+        example.run
+      end
+    end
+
+    before do
+      allow(redis_client)
+        .to receive(:set).with("healthcheck-abc", anything)
+    end
+
+    it_behaves_like "a healthcheck"
+
+    it "returns OK" do
+      expect(subject.status).to eq(GovukHealthcheck::OK)
+    end
+  end
+
+  context "when redis is not available" do
+    around(:example) do |example|
+      ClimateControl.modify EMERGENCY_BANNER_REDIS_URL: redis_bad_url do
+        example.run
+      end
+    end
+
+    it_behaves_like "a healthcheck"
+
+    it "returns CRITICAL" do
+      expect(subject.status).to eq(GovukHealthcheck::CRITICAL)
+    end
+  end
+end


### PR DESCRIPTION
Apps that stop relying on static need to reach into the emergency banner redis to check if there's a banner that should be displayed, but we don't have a health check for that config/connectivity, and it's already common across than more than one app.

Static itself is a good example, if the emergency banner redis isn't available static returns errors. I need to add a check of that emergency banner redis connectivity to the startupProbes for static, so it seemed sensible to make this a reusable healthcheck rather than solely implementing it in static.

When I update static to use this, I will also update it's docs to instruct that this healthcheck should be added to apps which remove their static dependency

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
