### PR TITLE
Instrument Puma processes in prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.21.0
+
+* Add Prometheus monitoring of Puma processes
+
 # 9.20.7
 
 * Implemented workaround for Logstasher initializer conflict under Rails 8.1

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.20.7".freeze
+  VERSION = "9.21.0".freeze
 end


### PR DESCRIPTION
There are [extra metrics around Puma processes](https://github.com/discourse/prometheus_exporter?tab=readme-ov-file#puma-metrics) that we can use.

I'm particularly interested in request backlogs (possibly to use in auto-scaling) and GC time for large requests.

I considered putting this code in `govuk_prometheus_exporter.rb`, but Puma doesn't appear to have the same ability to interact outside of the standard `puma.rb` approach, that say Sidekiq does.


### Details (copied from the prometheus_exporter project linked above)

#### Metrics collected by Puma Instrumentation

| Type  | Name                        | Description                                                                                                         |
| ---   | ---                         | ---                                                                                                                 |
| Gauge | `puma_workers`              | Number of puma workers                                                                                              |
| Gauge | `puma_booted_workers`       | Number of puma workers booted                                                                                       |
| Gauge | `puma_old_workers`          | Number of old puma workers                                                                                          |
| Gauge | `puma_running_threads`      | How many threads are spawned. A spawned thread may be busy processing a request or waiting for a new request        |
| Gauge | `puma_request_backlog`      | Number of requests waiting to be processed by a puma thread                                                         |
| Gauge | `puma_thread_pool_capacity` | Number of puma threads available at current scale                                                                   |
| Gauge | `puma_max_threads`          | Number of puma threads at available at max scale                                                                    |
| Gauge | `puma_busy_threads`         | Running - how many threads are waiting to receive work + how many requests are waiting for a thread to pick them up |

All metrics may have a `phase` label and all custom labels provided with the `labels` option.

#### Metrics collected by Process Instrumentation

| Type    | Name                      | Description                                  |
| ---     | ---                       | ---                                          |
| Gauge   | `heap_free_slots`         | Free ruby heap slots                         |
| Gauge   | `heap_live_slots`         | Used ruby heap slots                         |
| Gauge   | `v8_heap_size`*           | Total JavaScript V8 heap size (bytes)        |
| Gauge   | `v8_used_heap_size`*      | Total used JavaScript V8 heap size (bytes)   |
| Gauge   | `v8_physical_size`*       | Physical size consumed by V8 heaps           |
| Gauge   | `v8_heap_count`*          | Number of V8 contexts running                |
| Gauge   | `rss`                     | Total RSS used by process                    |
| Counter | `major_gc_ops_total`      | Major GC operations by process               |
| Counter | `minor_gc_ops_total`      | Minor GC operations by process               |
| Counter | `allocated_objects_total` | Total number of allocated objects by process |
| Gauge   | `marking_time`            | Marking time spent (Ruby 3.3 minimum)        |
| Gauge   | `sweeping_time`           | Sweeping time spent (Ruby 3.3 minimum)       |

_Metrics marked with * are only collected when `MiniRacer` is defined._

Metrics collected by Process instrumentation include labels `type` (as given with the `type` option), `pid` (of the process the stats where collected in), and any custom labels given to `Process.start` with the `labels` option.
