### PR TITLE
Add extra google analytics domains to content security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.22.0
+
+* Add extra google analytics domains to content security policy
+
 # 9.21.0
 
 * Add Prometheus monitoring of Puma processes

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -20,7 +20,9 @@ module GovukContentSecurityPolicy
                                 stats.g.doubleclick.net
                                 www.googletagmanager.com
                                 www.region1.google-analytics.com
-                                region1.google-analytics.com].freeze
+                                region1.google-analytics.com
+                                region1.analytics.google.com
+                                www.google.co.uk].freeze
 
   GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.21.0".freeze
+  VERSION = "9.22.0".freeze
 end


### PR DESCRIPTION
## What/Why
- Add extra google analytics domains to content security policy
- As requested by performance analysts as they're enabling Google Signals
- Domains added here are from the CSP errors we got when they tried to enable Google Signals (see screenshot)

<img width="1200" height="1180" alt="image" src="https://github.com/user-attachments/assets/067c7329-a1d7-4eab-baf5-4f7d48e5d810" />
