### PR TITLE
Remove single consent domains from CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.23.7
+
+* Remove single consent domains from connect_src CSP configuration
+
 # 9.23.6
 
 * Update dependencies

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -73,9 +73,7 @@ module GovukContentSecurityPolicy
                        *GOVUK_DOMAINS,
                        *GOOGLE_ANALYTICS_DOMAINS,
                        # Speedcurve real user monitoring (RUM) - as per: https://support.speedcurve.com/docs/add-rum-to-your-csp
-                       "lux.speedcurve.com",
-                       "gds-single-consent-staging.app",
-                       "gds-single-consent.app"
+                       "lux.speedcurve.com"
 
     # Disallow all <object>, <embed>, and <applet> elements
     #

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.6".freeze
+  VERSION = "9.23.7".freeze
 end


### PR DESCRIPTION
These allowed testing with the [cross-domain single consent](https://gds.blog.gov.uk/2022/10/17/the-single-data-environment-joined-up-digital-analytics/) API, but are not required at the moment.

Removing to improve security posture.
