### PR TITLE
Fix Google Analytics CSP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.23.8
+
+* Fix Google Analytics CSP errors
+
 # 9.23.7
 
 * Remove single consent domains from connect_src CSP configuration

--- a/lib/govuk_app_config/govuk_content_security_policy.rb
+++ b/lib/govuk_app_config/govuk_content_security_policy.rb
@@ -21,8 +21,10 @@ module GovukContentSecurityPolicy
                                 www.googletagmanager.com
                                 www.region1.google-analytics.com
                                 region1.google-analytics.com
-                                region1.analytics.google.com
-                                www.google.co.uk].freeze
+                                www.google.co.uk
+                                analytics.google.com
+                                *.analytics.google.com
+                                www.google.com].freeze
 
   GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.7".freeze
+  VERSION = "9.23.8".freeze
 end


### PR DESCRIPTION
Without these extra domains, looks like our tracking doesn't work outside the EU (Australia, India, USA, etc.)

JIRA Card: https://gov-uk.atlassian.net/browse/IA-2681

<img width="561" height="305" alt="image" src="https://github.com/user-attachments/assets/c6c41532-2aab-4672-8266-048b927b4202" />


⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
