### PR TITLE
Fix Logstasher in Rails apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.23.9
+
+* Fix Logstasher JSON logger initialisation problems in Rails apps
+
 # 9.23.8
 
 * Fix Google Analytics CSP errors

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -95,5 +95,12 @@ module GovukJsonLogging
       # the responses it gets, so direct this to the logstasher logger.
       GdsApi::Base.default_options[:logger] = Rails.application.config.logstasher.logger
     end
+
+    # On Rails 8.1+, the default LogStasher initializer is removed to prevent a boot
+    # crash (see railtie.rb). We call setup explicitly here, after all config is applied.
+    if defined?(LogStasher) && Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("8.1")
+      LogStasher.setup_before(Rails.application.config.logstasher)
+      LogStasher.setup(Rails.application.config.logstasher)
+    end
   end
 end

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -7,13 +7,10 @@ begin
   # Only apply this workaround for Rails 8.1+ where the boot cycle issue exists.
   # This prevents any potential regressions for apps on older Rails versions.
   if defined?(LogStasher::Railtie) && Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("8.1")
-    # Remove duplicate initializers that cause cyclic dependency
+    # Remove the default initializer to fix a cyclic dependency boot crash on Rails 8.1.
+    # LogStasher.setup is instead called explicitly in GovukJsonLogging.configure (after_initialize),
+    # once logstasher.enabled has been set to true.
     LogStasher::Railtie.initializers.delete_if { |i| i.name == :logstasher }
-
-    # Replace with a single clean initializer that actually sets up LogStasher
-    LogStasher::Railtie.initializer(:logstasher_govuk_fix, after: :load_config_initializers) do |app|
-      LogStasher.setup(app) if app.config.logstasher.enabled
-    end
   end
 rescue LoadError, NameError
   # Skip if Logstasher not present

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.8".freeze
+  VERSION = "9.23.9".freeze
 end


### PR DESCRIPTION
Rails 8.1 compatibility fixes appear to have broken json logging in rails apps.

There were a couple of problems:

- Setting up the logstasher configuration in the Railtie, might have been trying to configure things before logstasher.enabled was true, therefore nothing happened
- Logstasher has two setup methods ([setup](https://github.com/shadabahmed/logstasher/blob/0fdc1b939acac7c03736933450d3a810b0084793/lib/logstasher/railtie.rb#L58) and [setup_before](https://github.com/shadabahmed/logstasher/blob/0fdc1b939acac7c03736933450d3a810b0084793/lib/logstasher/railtie.rb#L53)) and we'd only called one of them.

`setup_before` relies on the state of `config.enabled` which is set to true in govuk_json_logging above.
It then [attaches log subscribers](https://github.com/shadabahmed/logstasher/blob/0fdc1b939acac7c03736933450d3a810b0084793/lib/logstasher.rb#L124C5-L129C104) to controllers, mailers, records, views and jobs

`setup` does the rest of the initialisation, [setting configuration such as logging locations](https://github.com/shadabahmed/logstasher/blob/0fdc1b939acac7c03736933450d3a810b0084793/lib/logstasher.rb#L133-L147), levels and the like.
