### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
+---
 version: 2
 updates:
 - package-ecosystem: bundler
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
-- package-ecosystem: "github-actions"
-  directory: "/"
+  cooldown:
+    default-days: 10
+- package-ecosystem: github-actions
+  directory: /
   schedule:
     interval: daily
+  cooldown:
+    default-days: 10
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.23.10
+* Set dependency cooldowns in Dependabot
+
 # 9.23.9
 
 * Fix Logstasher JSON logger initialisation problems in Rails apps

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.9".freeze
+  VERSION = "9.23.10".freeze
 end


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
