### PR TITLE
Prevent double initialisation of Logstasher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+# 9.23.11
+
+* Fix dual boot of Logstasher configuration
+* Add request_uri to rails log fields
+
 # 9.23.10
+
 * Set dependency cooldowns in Dependabot
 
 # 9.23.9

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -56,6 +56,7 @@ module GovukJsonLogging
       # Mirrors Nginx request logging, e.g. GET /path/here HTTP/1.1
       fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
 
+      fields[:request_uri] = request.fullpath
       fields[:govuk_request_id] = request.headers["GOVUK-Request-Id"]
       fields[:varnish_id] = request.headers["X-Varnish"]
       fields[:govuk_app_config] = GovukAppConfig::VERSION

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -16,6 +16,10 @@ module GovukJsonLogging
   end
 
   def self.configure(&block)
+    return if @configured
+
+    @configured = true
+
     # Fixes the monkey patch from the logstasher gem to support Rails 7
     config = Rails.application.config.logstasher
     if (!config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.10".freeze
+  VERSION = "9.23.11".freeze
 end

--- a/spec/lib/govuk_json_logging_spec.rb
+++ b/spec/lib/govuk_json_logging_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe GovukJsonLogging do
     end)
   end
 
-  after { Rails.application = nil }
+  after do
+    Rails.application = nil
+    GovukJsonLogging.instance_variable_set(:@configured, nil)
+  end
 
   # By storing origin stdout in a constant and redirect `$stdout` to a fake one,
   # We are able to inspect and test what is printed
@@ -53,6 +56,12 @@ RSpec.describe GovukJsonLogging do
   end
 
   describe ".configure" do
+    it "does not configure twice if called more than once" do
+      expect(Rails.application.config.logstasher).to receive(:enabled=).once.and_call_original
+      GovukJsonLogging.configure
+      GovukJsonLogging.configure
+    end
+
     it "enables logstasher" do
       Rails.application.config.logstasher.enabled = false
       expect { GovukJsonLogging.configure }


### PR DESCRIPTION
Apps that configure their own custom fields can now inadvertently register two listeners, since [the last change which fixed a boot race condition](https://github.com/alphagov/govuk_app_config/commit/f130c88be5b384c4c7891abce9503123efc4fac1).

This change adds a check to see if the configuration has already run. The [app logstasher initialiser](https://github.com/alphagov/content-store/blob/main/config/initializers/logstasher.rb#L2) runs before the [gem's railtie after_initialize hook](https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/railtie.rb#L32), so this should now work correctly.Prevent double initialisation

Apps that configure their own custom fields are currently able to inadvertently register two listeners, since [the last change which fixed a boot race condition](https://github.com/alphagov/govuk_app_config/commit/f130c88be5b384c4c7891abce9503123efc4fac1).

This change adds a check to see if the configuration has already run. The [app logstasher initialiser](https://github.com/alphagov/content-store/blob/main/config/initializers/logstasher.rb#L2) runs before the [gem's railtie after_initialize hook](https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/railtie.rb#L32), so this should now work correctly and only register once, and include custom fields if some are supplied.

Example of dual logging:
<img width="1391" height="195" alt="Screenshot 2026-04-16 at 17 31 06" src="https://github.com/user-attachments/assets/ea6d3519-58a4-4918-8f8f-76be8f8ccb66" />

## Also add a request_uri logging field to Rails Json logs

This matches the Nginx request_uri field, and includes the query string, which the current path log field does not.

This should make it easier to search for `request_uri: \/search\/all*` and get everything, rather than just Nginx logs