### PR TITLE
Make OpenTelemetry service name configurable via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.24.0
+
+* Make OpenTelemetry service name configurable via environment variable `GOVUK_OTEL_SERVICE_NAME`
+
 # 9.23.11
 
 * Fix dual boot of Logstasher configuration

--- a/lib/govuk_app_config/railtie.rb
+++ b/lib/govuk_app_config/railtie.rb
@@ -20,7 +20,8 @@ module GovukAppConfig
   class Railtie < Rails::Railtie
     initializer "govuk_app_config.configure_open_telemetry" do |app|
       unless Rails.const_defined?(:Console)
-        GovukOpenTelemetry.configure(app.class.module_parent_name.underscore)
+        service_name = ENV["GOVUK_OTEL_SERVICE_NAME"] || app.class.module_parent_name.underscore
+        GovukOpenTelemetry.configure(service_name)
       end
     end
 

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.23.11".freeze
+  VERSION = "9.24.0".freeze
 end


### PR DESCRIPTION
The Rails application module name will be used instead if the env var is not set

https://github.com/alphagov/govuk-infrastructure/issues/3914

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
