### PR TITLE
Add Puma::HttpParserError501 to error exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.25.0
+
+* Add Puma::HttpParserError501 to error exceptions
+
 # 9.24.1
 
 * Update dependencies

--- a/lib/govuk_app_config/govuk_error/configuration.rb
+++ b/lib/govuk_app_config/govuk_error/configuration.rb
@@ -43,6 +43,7 @@ module GovukError
         "GDS::SSO::PermissionDeniedError",
         "Mongoid::Errors::DocumentNotFound",
         "Puma::HttpParserError",
+        "Puma::HttpParserError501",
         "Sinatra::NotFound",
         "Sidekiq::JobRetry::Skip",
         "Sanitiser::Strategy::SanitisingError",

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.24.1".freeze
+  VERSION = "9.25.0".freeze
 end


### PR DESCRIPTION
- Puma v6 introduces this error which is thrown (along with returning a 501) when an http method that isn't marked as supported is called. It's arguable that this should be a 5xx series error, but it does follow the specs.
- (Discussion here: https://github.com/puma/puma/issues/3284)
- Whatever the situation, it's not actionable. We can't stop people calling gov.uk with weird methods, and as long as Puma is rejecting them, we don't need to get sentry errors about it. So, add to the exclude list.

Example error: 
https://govuk.sentry.io/issues/7508912668/?alert_rule_id=283788&alert_timestamp=1779879984920&alert_type=email&environment=production&notification_uuid=5159dd59-b4c3-4651-bf9b-66f6ecf11b08&project=202234

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
