### PR TITLE
4692-fix-logstasher-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.25.2
+
+Pass Rails log level through to logstasher
+
 # 9.25.1
 
 * Update dependencies

--- a/lib/govuk_app_config/govuk_json_logging.rb
+++ b/lib/govuk_app_config/govuk_json_logging.rb
@@ -104,6 +104,10 @@ module GovukJsonLogging
     # On Rails 8.1+, the default LogStasher initializer is removed to prevent a boot
     # crash (see railtie.rb). We call setup explicitly here, after all config is applied.
     if defined?(LogStasher) && Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("8.1")
+      # Without this line, logstasher setup falls back to WARN level. Instead,
+      # tell logstasher to use the same log level as Rails.
+      Rails.application.config.logstasher.log_level = Rails.logger.level
+
       LogStasher.setup_before(Rails.application.config.logstasher)
       LogStasher.setup(Rails.application.config.logstasher)
     end

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.25.1".freeze
+  VERSION = "9.25.2".freeze
 end


### PR DESCRIPTION
A fix to log initialisation for Rails 8.1 meant that logstasher was not finding the Rails log level, and defaulting to WARN. So, explicitly set logstasher's level to be the same as Rails.

Tests now pass:

```
$ bundle exec rake spec
...
Finished in 0.1641 seconds (files took 0.64997 seconds to load)
146 examples, 0 failures
```

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
