### PR TITLE
4692-try-to-trigger-ci-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gem "govuk_app_config"
 Then run `bundle`.
 
 
+
 ## Puma
 
 ### Configuration


### PR DESCRIPTION
DO NOT MERGE - triggering CI for debugging


⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
