### PR TITLE
Release v9.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.25.3
+
+* Update dependencies
+
 # 9.25.2
 
 Pass Rails log level through to logstasher

--- a/lib/govuk_app_config/version.rb
+++ b/lib/govuk_app_config/version.rb
@@ -1,3 +1,3 @@
 module GovukAppConfig
-  VERSION = "9.25.2".freeze
+  VERSION = "9.25.3".freeze
 end


### PR DESCRIPTION
All dependency upgrades, felt easier than waiting for CI to catch up

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/govuk_app_config/pull/356/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
